### PR TITLE
feat: harden library sync pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ A browsable archive of bookmarks (Readwise) and papers (Zotero) with hierarchica
 
 **Data Flow:**
 ```
-Readwise/Zotero APIs → sync.ts → SQLite → --export-library → library.json → /library page
+Readwise/Zotero APIs → sync.ts → SQLite sync_state/resources → --export-library → library.json → /library page
 ```
 
 **Key Files:**
@@ -136,8 +136,8 @@ TMDB_API_KEY=xxx
 ```
 
 **Updating the Library:**
-1. Run `bun sync api` to fetch latest from Readwise + Zotero (slow, rate limited)
-2. Run `bun sync --export-library` to regenerate JSON for Astro
+1. Run `bun sync api --export-library` to fetch latest resources and regenerate JSON
+2. Use `bun sync readwise --full` or `bun sync zotero --full` only for full backfills
 3. Edit `src/data/tag-hierarchy.json` to organize new tags
 4. Uncategorized tags appear at the bottom of the tag tree
 
@@ -192,21 +192,27 @@ API sources (Readwise, Zotero) ──┘
 # Granular sync
 bun sync books        # Goodreads CSV → SQLite
 bun sync music        # Spotify JSON → SQLite
-bun sync readwise     # Readwise API → SQLite (slow)
-bun sync zotero       # Zotero API → SQLite (slow)
+bun sync readwise     # Readwise API → SQLite (incremental after first run)
+bun sync zotero       # Zotero API → SQLite (incremental after first run)
 bun sync letterboxd   # Letterboxd RSS → SQLite
 bun sync rawg         # RAWG API → SQLite
 
 # Grouped sync
 bun sync local        # books + music (fast, no API calls)
-bun sync api          # readwise + zotero + letterboxd + rawg (slow, rate limited)
+bun sync api          # readwise + zotero + letterboxd + rawg
 bun sync all          # everything
 
+# Incremental/full controls
+bun sync readwise --full          # ignore saved Readwise state
+bun sync zotero --full            # ignore saved Zotero version
+bun sync readwise --since <ISO>   # override Readwise incremental timestamp
+
 # Export & stats
-bun sync --export-library   # SQLite → public/data/library.json
-bun sync --export-now       # SQLite → public/data/now.json (for /now page)
-bun sync --stats            # Show database stats
-bun sync --export TYPE      # Export to stdout (book|track|movie|game|article|paper|all)
+bun sync api --export-library     # sync APIs, then export library JSON
+bun sync --export-library         # SQLite → public/data/library.json
+bun sync --export-now             # SQLite → public/data/now.json (for /now page)
+bun sync --stats                  # Show database stats
+bun sync --export TYPE            # Export to stdout (book|track|movie|game|article|paper|all)
 ```
 
 ### Data Sources
@@ -223,19 +229,21 @@ bun sync --export TYPE      # Export to stdout (book|track|movie|game|article|pa
 
 ### API Sync Details
 
-The `bun sync api` command fetches from Readwise and Zotero APIs with built-in rate limiting:
+The `bun sync api` command fetches from API sources with built-in rate limiting:
 
-| API | Rate Limit | Delay Between Requests |
-|-----|------------|------------------------|
-| Readwise | 20 req/min | 3.5 seconds |
-| Zotero | 1 req/sec | 1.1 seconds |
+| API | Rate Limit | Delay Between Requests | Incremental State |
+|-----|------------|------------------------|-------------------|
+| Readwise | 20 req/min | 3.5 seconds | `updatedAfter` timestamp |
+| Zotero | 1 req/sec | 1.1 seconds | Zotero library version |
 
 **Features:**
-- **Pagination** — automatically fetches all pages
-- **Retry on 429** — respects `Retry-After` header, up to 3 retries
-- **Upsert** — existing resources updated, new ones inserted (no duplicates)
+- **Incremental by default** after the first successful Readwise/Zotero sync
+- **Full backfills** with `--full`; Readwise timestamp overrides with `--since <ISO>`
+- **Page-by-page upserts** with transactions and progress logs
+- **Retries/timeouts** for 429, transient 5xx, and network failures
+- **Atomic exports** for `library.json` and `now.json`
 
-**Typical runtime:** 2-5 minutes depending on library size.
+**Typical runtime:** first Readwise backfill can take several minutes for large libraries; later incremental runs should be much faster.
 
 ### Now Page (Media Queue)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Personal blog built with [Astro](https://astro.build).
 | `bun dev` | Start dev server at `localhost:4321` |
 | `bun build` | Build production site to `./dist/` |
 | `bun preview` | Preview build locally |
+| `bun sync api --export-library` | Sync Readwise/Zotero/etc. and export `/library` data |
+| `bun sync --stats` | Show local knowledge DB stats |
 
 ## Linting & Formatting
 
@@ -39,8 +41,11 @@ src/
 ├── pages/           # Routes
 ├── scripts/         # Client-side JS
 └── styles/          # Global CSS
+scripts/
+├── db.ts            # SQLite knowledge base helpers
+└── sync.ts          # Sync/export CLI
 public/
-└── data/            # Data files (Goodreads export, etc.)
+└── data/            # Generated/static data files
 ```
 
 ## Features
@@ -50,6 +55,30 @@ Interactive library explorer powered by Goodreads CSV export. Filter by shelf, d
 
 ### Music (`/music`)
 Music explorer for Spotify listening data.
+
+### Library (`/library`)
+Digital garden for Readwise and Zotero resources. Data flows through local SQLite, then exports to `public/data/library.json` for Astro.
+
+```bash
+bun sync api --export-library  # normal incremental sync + export
+bun sync readwise --full       # force full Readwise backfill
+bun sync zotero --full         # force full Zotero refresh
+bun sync readwise --since 2026-04-01T00:00:00Z
+bun sync --stats
+```
+
+Required `.env` values:
+
+```env
+READWISE_TOKEN=...
+ZOTERO_API_KEY=...
+ZOTERO_USER_ID=...
+```
+
+Notes:
+- First Readwise sync can take several minutes for large libraries.
+- Later Readwise/Zotero runs are incremental via saved `sync_state` in `data/knowledge.db`.
+- `data/` and generated JSON exports are ignored; regenerate them locally.
 
 ## Content
 

--- a/scripts/db.ts
+++ b/scripts/db.ts
@@ -33,8 +33,8 @@ export function getDb(): Database {
 			source TEXT NOT NULL, -- 'readwise' | 'zotero' | 'goodreads' | 'spotify' | 'manual'
 			source_id TEXT, -- ID from the source system
 			metadata TEXT, -- JSON for source-specific data
-			created_at TEXT DEFAULT (datetime('now')),
-			updated_at TEXT DEFAULT (datetime('now')),
+			created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 			classified_at TEXT,
 			UNIQUE(source, source_id)
 		)
@@ -46,7 +46,7 @@ export function getDb(): Database {
 			name TEXT NOT NULL UNIQUE,
 			parent_id INTEGER REFERENCES tags(id),
 			description TEXT,
-			created_at TEXT DEFAULT (datetime('now'))
+			created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 		)
 	`);
 
@@ -98,9 +98,45 @@ export function getDb(): Database {
 	if (!columnNames.has("date_published")) {
 		db.run("ALTER TABLE resources ADD COLUMN date_published TEXT");
 	}
+	if (!columnNames.has("reading_progress")) {
+		db.run("ALTER TABLE resources ADD COLUMN reading_progress REAL");
+	}
+	if (!columnNames.has("item_type")) {
+		db.run("ALTER TABLE resources ADD COLUMN item_type TEXT");
+	}
+	if (!columnNames.has("publication_title")) {
+		db.run("ALTER TABLE resources ADD COLUMN publication_title TEXT");
+	}
+	if (!columnNames.has("source_created_at")) {
+		db.run("ALTER TABLE resources ADD COLUMN source_created_at TEXT");
+	}
+	if (!columnNames.has("source_updated_at")) {
+		db.run("ALTER TABLE resources ADD COLUMN source_updated_at TEXT");
+	}
+	if (!columnNames.has("last_seen_at")) {
+		db.run("ALTER TABLE resources ADD COLUMN last_seen_at TEXT");
+	}
+
+	db.run(`
+		CREATE TABLE IF NOT EXISTS sync_state (
+			source TEXT PRIMARY KEY,
+			last_started_at TEXT,
+			last_success_at TEXT,
+			high_water_mark TEXT,
+			version INTEGER,
+			metadata TEXT,
+			updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		)
+	`);
 
 	db.run(
 		"CREATE INDEX IF NOT EXISTS idx_resources_status ON resources(status)",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_resources_source_created ON resources(source_created_at)",
+	);
+	db.run(
+		"CREATE INDEX IF NOT EXISTS idx_resources_last_seen ON resources(last_seen_at)",
 	);
 
 	return db;
@@ -134,6 +170,16 @@ export type ResourceSource =
 
 export type ConsumptionStatus = "now" | "next" | "done" | "dropped" | null;
 
+export interface SyncState {
+	source: ResourceSource;
+	last_started_at?: string;
+	last_success_at?: string;
+	high_water_mark?: string;
+	version?: number;
+	metadata?: Record<string, unknown>;
+	updated_at?: string;
+}
+
 export interface Resource {
 	id: string;
 	type: ResourceType;
@@ -148,10 +194,13 @@ export interface Resource {
 	created_at?: string;
 	updated_at?: string;
 	classified_at?: string;
-	// Readwise-specific
+	// Source/library metadata
 	image_url?: string;
 	reading_progress?: number;
 	date_published?: string;
+	source_created_at?: string;
+	source_updated_at?: string;
+	last_seen_at?: string;
 	// Zotero-specific
 	item_type?: string;
 	publication_title?: string;
@@ -164,12 +213,64 @@ export interface Resource {
 	queue_priority?: number;
 }
 
+export function getSyncState(
+	db: Database,
+	source: ResourceSource,
+): SyncState | undefined {
+	const row = db
+		.prepare("SELECT * FROM sync_state WHERE source = ?")
+		.get(source) as Record<string, unknown> | undefined;
+
+	if (!row) return undefined;
+
+	return {
+		source: row.source as ResourceSource,
+		last_started_at: row.last_started_at as string | undefined,
+		last_success_at: row.last_success_at as string | undefined,
+		high_water_mark: row.high_water_mark as string | undefined,
+		version:
+			typeof row.version === "number"
+				? row.version
+				: row.version
+					? Number(row.version)
+					: undefined,
+		metadata: row.metadata
+			? (JSON.parse(row.metadata as string) as Record<string, unknown>)
+			: undefined,
+		updated_at: row.updated_at as string | undefined,
+	};
+}
+
+export function saveSyncState(db: Database, state: SyncState): void {
+	db.prepare(
+		`
+		INSERT INTO sync_state (source, last_started_at, last_success_at, high_water_mark, version, metadata, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		ON CONFLICT(source) DO UPDATE SET
+			last_started_at = excluded.last_started_at,
+			last_success_at = excluded.last_success_at,
+			high_water_mark = excluded.high_water_mark,
+			version = excluded.version,
+			metadata = excluded.metadata,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+	`,
+	).run(
+		state.source,
+		state.last_started_at ?? null,
+		state.last_success_at ?? null,
+		state.high_water_mark ?? null,
+		state.version ?? null,
+		state.metadata ? JSON.stringify(state.metadata) : null,
+	);
+}
+
 // Insert or update a resource
 export function upsertResource(db: Database, resource: Resource): void {
 	const stmt = db.prepare(`
 		INSERT INTO resources (id, type, title, url, author, description, tags, source, source_id, metadata, 
-			status, status_manual, platform_status, favorited, rating, queue_priority, image_url, date_published, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+			status, status_manual, platform_status, favorited, rating, queue_priority, image_url, date_published,
+			reading_progress, item_type, publication_title, source_created_at, source_updated_at, last_seen_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 		ON CONFLICT(id) DO UPDATE SET
 			type = excluded.type,
 			title = excluded.title,
@@ -183,12 +284,19 @@ export function upsertResource(db: Database, resource: Resource): void {
 			platform_status = excluded.platform_status,
 			image_url = COALESCE(excluded.image_url, resources.image_url),
 			date_published = COALESCE(excluded.date_published, resources.date_published),
-			-- Only update status/priority if NOT manually curated
+			reading_progress = COALESCE(excluded.reading_progress, resources.reading_progress),
+			item_type = COALESCE(excluded.item_type, resources.item_type),
+			publication_title = COALESCE(excluded.publication_title, resources.publication_title),
+			source_created_at = COALESCE(excluded.source_created_at, resources.source_created_at),
+			source_updated_at = COALESCE(excluded.source_updated_at, resources.source_updated_at),
+			last_seen_at = COALESCE(excluded.last_seen_at, resources.last_seen_at),
+			status_manual = MAX(resources.status_manual, excluded.status_manual),
+			-- Only update status/priority if the existing row is not manually curated
 			status = CASE WHEN resources.status_manual = 1 THEN resources.status ELSE excluded.status END,
 			queue_priority = CASE WHEN resources.status_manual = 1 THEN resources.queue_priority ELSE excluded.queue_priority END,
 			favorited = COALESCE(excluded.favorited, resources.favorited),
 			rating = COALESCE(excluded.rating, resources.rating),
-			updated_at = datetime('now')
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 	`);
 
 	stmt.run(
@@ -210,6 +318,12 @@ export function upsertResource(db: Database, resource: Resource): void {
 		resource.queue_priority ?? null,
 		resource.image_url ?? null,
 		resource.date_published ?? null,
+		resource.reading_progress ?? null,
+		resource.item_type ?? null,
+		resource.publication_title ?? null,
+		resource.source_created_at ?? null,
+		resource.source_updated_at ?? null,
+		resource.last_seen_at ?? null,
 	);
 }
 
@@ -245,7 +359,9 @@ export function getAllResources(db: Database): Resource[] {
 // Get library resources (readwise + zotero)
 export function getLibraryResources(db: Database): Resource[] {
 	const stmt = db.prepare(
-		"SELECT * FROM resources WHERE source IN ('readwise', 'zotero') ORDER BY created_at DESC",
+		`SELECT * FROM resources
+		WHERE source IN ('readwise', 'zotero')
+		ORDER BY COALESCE(source_created_at, created_at) DESC, id ASC`,
 	);
 	const rows = stmt.all() as Record<string, unknown>[];
 

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -1,4 +1,5 @@
-import { writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { parseArgs } from "node:util";
 import {
 	exportAsJson,
@@ -6,8 +7,10 @@ import {
 	getLibraryResources,
 	getNowResources,
 	getStats,
+	getSyncState,
 	type Resource,
 	type ResourceType,
+	saveSyncState,
 	upsertResource,
 } from "./db";
 
@@ -27,10 +30,78 @@ const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
 
 const READWISE_DELAY_MS = 3500; // ~17 requests/minute (limit is 20)
 const ZOTERO_DELAY_MS = 1100; // 1 request/sec per API guidance
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 4;
+const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_RETRY_WAIT_MS = 120_000;
+const INCREMENTAL_OVERLAP_MS = 5 * 60 * 1000;
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function formatDuration(ms: number): string {
+	const seconds = Math.round(ms / 1000);
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	return `${minutes}m ${remainingSeconds}s`;
+}
+
+function normalizeIsoDate(value?: string | null): string | undefined {
+	if (!value) return undefined;
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function withOverlap(timestamp?: string): string | undefined {
+	if (!timestamp) return undefined;
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) return timestamp;
+	return new Date(date.getTime() - INCREMENTAL_OVERLAP_MS).toISOString();
+}
+
+function sanitizeUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		return `${parsed.origin}${parsed.pathname}`;
+	} catch {
+		return url.split("?")[0];
+	}
+}
+
+function parseRetryAfter(header: string | null): number | undefined {
+	if (!header) return undefined;
+	const seconds = Number.parseInt(header, 10);
+	if (!Number.isNaN(seconds)) return seconds * 1000;
+
+	const date = new Date(header);
+	if (!Number.isNaN(date.getTime())) {
+		return Math.max(0, date.getTime() - Date.now());
+	}
+
+	return undefined;
+}
+
+function getRetryWaitMs(
+	response: Response | undefined,
+	attempt: number,
+): number {
+	const retryAfter = parseRetryAfter(
+		response?.headers.get("Retry-After") ?? null,
+	);
+	if (retryAfter !== undefined) return Math.min(retryAfter, MAX_RETRY_WAIT_MS);
+
+	const exponential = Math.min(2 ** attempt * 1000, 30_000);
+	const jitter = Math.floor(Math.random() * 1000);
+	return Math.min(exponential + jitter, MAX_RETRY_WAIT_MS);
+}
+
+function isRetryableStatus(status: number): boolean {
+	return [408, 429, 500, 502, 503, 504].includes(status);
 }
 
 // Parse a single CSV line handling quoted fields
@@ -68,17 +139,62 @@ async function fetchWithRetry(
 	options: RequestInit,
 	retries = MAX_RETRIES,
 ): Promise<Response> {
-	const response = await fetch(url, options);
+	for (let attempt = 0; attempt <= retries; attempt++) {
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-	if (response.status === 429 && retries > 0) {
-		const retryAfter = response.headers.get("Retry-After");
-		const waitMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : 60000;
-		console.log(`  Rate limited, waiting ${waitMs / 1000}s...`);
-		await delay(waitMs);
-		return fetchWithRetry(url, options, retries - 1);
+		try {
+			const response = await fetch(url, {
+				...options,
+				signal: controller.signal,
+			});
+
+			if (!isRetryableStatus(response.status) || attempt === retries) {
+				return response;
+			}
+
+			const waitMs = getRetryWaitMs(response, attempt);
+			console.log(
+				`  ${response.status} from ${sanitizeUrl(url)}; retry ${attempt + 1}/${retries} in ${formatDuration(waitMs)}`,
+			);
+			await delay(waitMs);
+		} catch (error) {
+			if (attempt === retries) throw error;
+
+			const waitMs = getRetryWaitMs(undefined, attempt);
+			const message = error instanceof Error ? error.message : String(error);
+			console.log(
+				`  Request failed for ${sanitizeUrl(url)} (${message}); retry ${attempt + 1}/${retries} in ${formatDuration(waitMs)}`,
+			);
+			await delay(waitMs);
+		} finally {
+			clearTimeout(timeout);
+		}
 	}
 
-	return response;
+	throw new Error(
+		`Request failed after ${retries + 1} attempts: ${sanitizeUrl(url)}`,
+	);
+}
+
+async function requireOk(response: Response, source: string): Promise<void> {
+	if (response.ok) return;
+
+	const body = await response.text().catch(() => "");
+	const detail = body ? ` — ${body.slice(0, 500)}` : "";
+	throw new Error(
+		`${source} API error: ${response.status} ${response.statusText}${detail}`,
+	);
+}
+
+function upsertResourceBatch(
+	db: ReturnType<typeof getDb>,
+	resources: Resource[],
+): void {
+	const insertMany = db.transaction((batch: Resource[]) => {
+		for (const resource of batch) upsertResource(db, resource);
+	});
+	insertMany(resources);
 }
 
 // Parse Goodreads CSV (reusing logic from src/scripts/books.ts)
@@ -231,6 +347,7 @@ interface ReadwiseDocument {
 	summary: string | null;
 	image_url: string | null;
 	created_at: string;
+	updated_at?: string | null;
 	published_date: string | null;
 	category: string;
 	tags: ReadwiseTag[];
@@ -254,68 +371,126 @@ const READWISE_CATEGORY_MAP: Record<string, ResourceType> = {
 	rss: "article",
 };
 
-async function syncReadwise(db: ReturnType<typeof getDb>) {
+interface ReadwiseSyncOptions {
+	full?: boolean;
+	since?: string;
+}
+
+function readwiseDocToResource(
+	doc: ReadwiseDocument,
+	seenAt: string,
+): Resource {
+	const tags = Array.isArray(doc.tags)
+		? doc.tags.map((t) => t.name).filter(Boolean)
+		: [];
+
+	return {
+		id: `rw-${doc.id}`,
+		type: READWISE_CATEGORY_MAP[doc.category] || "bookmark",
+		title: doc.title || "Untitled",
+		url: doc.url || undefined,
+		author: doc.author || undefined,
+		description: doc.summary || undefined,
+		tags,
+		source: "readwise",
+		source_id: doc.id,
+		image_url: doc.image_url || undefined,
+		reading_progress: doc.reading_progress,
+		date_published: normalizeIsoDate(doc.published_date),
+		source_created_at: normalizeIsoDate(doc.created_at),
+		source_updated_at: normalizeIsoDate(doc.updated_at),
+		last_seen_at: seenAt,
+		metadata: {
+			category: doc.category,
+			created_at: doc.created_at,
+			updated_at: doc.updated_at ?? null,
+		},
+	};
+}
+
+async function syncReadwise(
+	db: ReturnType<typeof getDb>,
+	options: ReadwiseSyncOptions = {},
+) {
 	if (!READWISE_TOKEN) {
 		console.log("📚 READWISE_TOKEN not set, skipping Readwise sync");
 		return 0;
 	}
 
+	const startedAt = nowIso();
+	const startedMs = Date.now();
+	const state = getSyncState(db, "readwise");
+	const incrementalSince = options.full
+		? undefined
+		: withOverlap(
+				options.since || state?.high_water_mark || state?.last_success_at,
+			);
+
 	console.log("📚 Fetching Readwise documents...");
-	const docs: ReadwiseDocument[] = [];
+	console.log(
+		incrementalSince
+			? `  Mode: incremental since ${incrementalSince}`
+			: "  Mode: full sync",
+	);
+
 	let cursor: string | null = null;
+	let count = 0;
+	let page = 0;
+	let latestSourceUpdate: string | undefined;
 
 	do {
 		const url = new URL("https://readwise.io/api/v3/list/");
 		if (cursor) url.searchParams.set("pageCursor", cursor);
+		if (incrementalSince)
+			url.searchParams.set("updatedAfter", incrementalSince);
 
 		const response = await fetchWithRetry(url.toString(), {
 			headers: { Authorization: `Token ${READWISE_TOKEN}` },
 		});
-
-		if (!response.ok) {
-			throw new Error(
-				`Readwise API error: ${response.status} ${response.statusText}`,
-			);
-		}
+		await requireOk(response, "Readwise");
 
 		const data: ReadwiseResponse = await response.json();
-		docs.push(...data.results);
-		cursor = data.nextPageCursor;
+		const resources = data.results.map((doc) => {
+			const updatedAt =
+				normalizeIsoDate(doc.updated_at) || normalizeIsoDate(doc.created_at);
+			if (
+				updatedAt &&
+				(!latestSourceUpdate || updatedAt > latestSourceUpdate)
+			) {
+				latestSourceUpdate = updatedAt;
+			}
+			return readwiseDocToResource(doc, startedAt);
+		});
 
-		console.log(`  Fetched ${docs.length} documents...`);
+		if (resources.length > 0) upsertResourceBatch(db, resources);
+
+		cursor = data.nextPageCursor;
+		count += resources.length;
+		page++;
+
+		console.log(
+			`  Page ${page}: ${resources.length} docs (${count} total, ${formatDuration(Date.now() - startedMs)}, ${cursor ? "more" : "done"})`,
+		);
 
 		if (cursor) await delay(READWISE_DELAY_MS);
 	} while (cursor);
 
-	let count = 0;
-	for (const doc of docs) {
-		const tags = Array.isArray(doc.tags)
-			? doc.tags.map((t) => t.name).filter(Boolean)
-			: [];
+	saveSyncState(db, {
+		source: "readwise",
+		last_started_at: startedAt,
+		last_success_at: nowIso(),
+		high_water_mark: startedAt,
+		metadata: {
+			count,
+			full: !incrementalSince,
+			latestSourceUpdate: latestSourceUpdate ?? null,
+			durationMs: Date.now() - startedMs,
+		},
+	});
 
-		const resource: Resource = {
-			id: `rw-${doc.id}`,
-			type: READWISE_CATEGORY_MAP[doc.category] || "bookmark",
-			title: doc.title || "Untitled",
-			url: doc.url || undefined,
-			author: doc.author || undefined,
-			description: doc.summary || undefined,
-			tags,
-			source: "readwise",
-			source_id: doc.id,
-			image_url: doc.image_url || undefined,
-			reading_progress: doc.reading_progress,
-			date_published: doc.published_date || undefined,
-			metadata: {
-				category: doc.category,
-				created_at: doc.created_at,
-			},
-		};
-
-		upsertResource(db, resource);
-		count++;
-	}
-
+	console.log(
+		`  Saved Readwise sync state (${count} docs, ${formatDuration(Date.now() - startedMs)})`,
+	);
 	return count;
 }
 
@@ -342,13 +517,17 @@ interface ZoteroItemData {
 	creators: ZoteroCreator[];
 	abstractNote: string;
 	dateAdded: string;
+	dateModified?: string;
 	date: string;
 	publicationTitle: string;
+	contentType?: string;
+	filename?: string;
 	tags: ZoteroTag[];
 }
 
 interface ZoteroItem {
 	key: string;
+	version?: number;
 	data: ZoteroItemData;
 }
 
@@ -370,23 +549,81 @@ const ZOTERO_TYPE_MAP: Record<string, ResourceType> = {
 	document: "pdf",
 };
 
+function formatZoteroCreatorName(creator: ZoteroCreator): string | null {
+	if (creator.name) return creator.name;
+	if (creator.firstName && creator.lastName) {
+		return `${creator.firstName} ${creator.lastName}`;
+	}
+	if (creator.lastName) return creator.lastName;
+	return null;
+}
+
 function formatZoteroCreators(creators: ZoteroCreator[]): string | undefined {
 	if (!creators || creators.length === 0) return undefined;
 
-	const names = creators
+	const authors = creators
 		.filter((c) => c.creatorType === "author")
-		.map((c) => {
-			if (c.name) return c.name;
-			if (c.firstName && c.lastName) return `${c.firstName} ${c.lastName}`;
-			if (c.lastName) return c.lastName;
-			return null;
-		})
+		.map(formatZoteroCreatorName)
 		.filter(Boolean);
+	const fallbackCreators = creators
+		.map(formatZoteroCreatorName)
+		.filter(Boolean);
+	const names = authors.length > 0 ? authors : fallbackCreators;
 
 	return names.length > 0 ? names.join(", ") : undefined;
 }
 
-async function syncZotero(db: ReturnType<typeof getDb>) {
+interface ZoteroSyncOptions {
+	full?: boolean;
+}
+
+function getZoteroResourceType(data: ZoteroItemData): ResourceType {
+	if (
+		data.itemType === "attachment" &&
+		data.contentType === "application/pdf"
+	) {
+		return "pdf";
+	}
+
+	return ZOTERO_TYPE_MAP[data.itemType] || "other";
+}
+
+function zoteroItemToResource(item: ZoteroItem, seenAt: string): Resource {
+	const data = item.data;
+	const itemUrl =
+		data.url ||
+		`https://www.zotero.org/users/${ZOTERO_USER_ID}/items/${item.key}`;
+
+	return {
+		id: `zot-${item.key}`,
+		type: getZoteroResourceType(data),
+		title: data.title || data.filename || "Untitled",
+		url: itemUrl,
+		author: formatZoteroCreators(data.creators),
+		description: data.abstractNote || undefined,
+		tags: data.tags?.map((t) => t.tag).filter(Boolean) || [],
+		source: "zotero",
+		source_id: item.key,
+		item_type: data.itemType,
+		publication_title: data.publicationTitle || undefined,
+		date_published: normalizeIsoDate(data.date),
+		source_created_at: normalizeIsoDate(data.dateAdded),
+		source_updated_at: normalizeIsoDate(data.dateModified),
+		last_seen_at: seenAt,
+		metadata: {
+			dateAdded: data.dateAdded,
+			dateModified: data.dateModified ?? null,
+			version: item.version ?? null,
+			contentType: data.contentType ?? null,
+			filename: data.filename ?? null,
+		},
+	};
+}
+
+async function syncZotero(
+	db: ReturnType<typeof getDb>,
+	options: ZoteroSyncOptions = {},
+) {
 	if (!ZOTERO_API_KEY || !ZOTERO_USER_ID) {
 		console.log(
 			"📄 ZOTERO_API_KEY or ZOTERO_USER_ID not set, skipping Zotero sync",
@@ -394,72 +631,86 @@ async function syncZotero(db: ReturnType<typeof getDb>) {
 		return 0;
 	}
 
+	const startedAt = nowIso();
+	const startedMs = Date.now();
+	const state = getSyncState(db, "zotero");
+	const sinceVersion = options.full ? undefined : state?.version;
+
 	console.log("📄 Fetching Zotero items...");
-	const items: ZoteroItem[] = [];
+	console.log(
+		sinceVersion
+			? `  Mode: incremental since library version ${sinceVersion}`
+			: "  Mode: full sync",
+	);
+
 	let start = 0;
 	const limit = 100;
+	let count = 0;
+	let latestVersion = sinceVersion;
 
 	while (true) {
-		const url = `https://api.zotero.org/users/${ZOTERO_USER_ID}/items/top?limit=${limit}&start=${start}&format=json`;
+		const url = new URL(
+			`https://api.zotero.org/users/${ZOTERO_USER_ID}/items/top`,
+		);
+		url.searchParams.set("limit", String(limit));
+		url.searchParams.set("start", String(start));
+		url.searchParams.set("format", "json");
+		if (sinceVersion) url.searchParams.set("since", String(sinceVersion));
 
-		const response = await fetchWithRetry(url, {
+		const response = await fetchWithRetry(url.toString(), {
 			headers: {
 				"Zotero-API-Key": ZOTERO_API_KEY,
 				"Zotero-API-Version": "3",
 			},
 		});
+		await requireOk(response, "Zotero");
 
-		if (!response.ok) {
-			throw new Error(
-				`Zotero API error: ${response.status} ${response.statusText}`,
-			);
-		}
-
-		const data: ZoteroItem[] = await response.json();
-		if (data.length === 0) break;
-
-		items.push(...data);
-		start += limit;
+		const headerVersion = Number.parseInt(
+			response.headers.get("Last-Modified-Version") || "",
+			10,
+		);
+		if (!Number.isNaN(headerVersion)) latestVersion = headerVersion;
 
 		const total = Number.parseInt(
 			response.headers.get("Total-Results") || "0",
 			10,
 		);
-		console.log(`  Fetched ${items.length}/${total} items...`);
+		const data: ZoteroItem[] = await response.json();
+		if (data.length === 0) {
+			console.log(
+				`  No Zotero changes (${formatDuration(Date.now() - startedMs)})`,
+			);
+			break;
+		}
+
+		const resources = data.map((item) => zoteroItemToResource(item, startedAt));
+		upsertResourceBatch(db, resources);
+
+		count += resources.length;
+		start += limit;
+		console.log(
+			`  Fetched ${count}/${total} items (version ${latestVersion ?? "unknown"}, ${formatDuration(Date.now() - startedMs)})`,
+		);
 
 		if (start >= total) break;
 		await delay(ZOTERO_DELAY_MS);
 	}
 
-	let count = 0;
-	for (const item of items) {
-		const data = item.data;
-		const itemUrl =
-			data.url ||
-			`https://www.zotero.org/users/${ZOTERO_USER_ID}/items/${item.key}`;
+	saveSyncState(db, {
+		source: "zotero",
+		last_started_at: startedAt,
+		last_success_at: nowIso(),
+		version: latestVersion,
+		metadata: {
+			count,
+			full: !sinceVersion,
+			durationMs: Date.now() - startedMs,
+		},
+	});
 
-		const resource: Resource = {
-			id: `zot-${item.key}`,
-			type: ZOTERO_TYPE_MAP[data.itemType] || "other",
-			title: data.title || "Untitled",
-			url: itemUrl,
-			author: formatZoteroCreators(data.creators),
-			description: data.abstractNote || undefined,
-			tags: data.tags?.map((t) => t.tag) || [],
-			source: "zotero",
-			source_id: item.key,
-			item_type: data.itemType,
-			publication_title: data.publicationTitle || undefined,
-			date_published: data.date || undefined,
-			metadata: {
-				dateAdded: data.dateAdded,
-			},
-		};
-
-		upsertResource(db, resource);
-		count++;
-	}
-
+	console.log(
+		`  Saved Zotero sync state (${count} items, ${formatDuration(Date.now() - startedMs)})`,
+	);
 	return count;
 }
 
@@ -958,6 +1209,79 @@ async function albumAddById(
 	);
 }
 
+// ============================================================================
+// Export helpers
+// ============================================================================
+
+function atomicWriteJson(path: string, data: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tempPath = `${path}.tmp`;
+	writeFileSync(tempPath, `${JSON.stringify(data, null, 2)}\n`);
+	renameSync(tempPath, path);
+}
+
+function exportLibrary(db: ReturnType<typeof getDb>): number {
+	const resources = getLibraryResources(db);
+
+	const frontendResources = resources.map((r) => ({
+		id: r.id,
+		source: r.source,
+		type: r.type,
+		title: r.title,
+		url: r.url || "",
+		author: r.author || null,
+		description: r.description || null,
+		dateAdded:
+			normalizeIsoDate(r.source_created_at) ||
+			normalizeIsoDate(r.created_at) ||
+			nowIso(),
+		datePublished: normalizeIsoDate(r.date_published) || null,
+		tags: r.tags || [],
+		imageUrl: r.image_url || null,
+		readingProgress: r.reading_progress,
+		itemType: r.item_type,
+		publicationTitle: r.publication_title,
+	}));
+
+	atomicWriteJson("./public/data/library.json", {
+		fetchedAt: nowIso(),
+		resources: frontendResources,
+	});
+	console.log(
+		`📚 Exported ${resources.length} library resources to ./public/data/library.json`,
+	);
+	return resources.length;
+}
+
+function exportNow(db: ReturnType<typeof getDb>): number {
+	const resources = getNowResources(db);
+
+	const frontendResources = resources.map((r) => ({
+		id: r.id,
+		source: r.source,
+		type: r.type,
+		title: r.title,
+		url: r.url || "",
+		author: r.author || null,
+		description: r.description || null,
+		imageUrl: r.image_url || null,
+		status: r.status,
+		queuePriority: r.queue_priority,
+		platformStatus: r.platform_status,
+		favorited: r.favorited === 1,
+		rating: r.rating || null,
+	}));
+
+	atomicWriteJson("./public/data/now.json", {
+		exportedAt: nowIso(),
+		resources: frontendResources,
+	});
+	console.log(
+		`🎯 Exported ${resources.length} now queue resources to ./public/data/now.json`,
+	);
+	return resources.length;
+}
+
 // CLI
 const { values, positionals } = parseArgs({
 	args: Bun.argv.slice(2),
@@ -967,6 +1291,8 @@ const { values, positionals } = parseArgs({
 		stats: { type: "boolean", short: "s" },
 		"export-library": { type: "boolean" },
 		"export-now": { type: "boolean" },
+		full: { type: "boolean" },
+		since: { type: "string" },
 	},
 	allowPositionals: true,
 });
@@ -1002,15 +1328,20 @@ Options:
   -e, --export TYPE     Export resources as JSON to stdout (book|track|movie|game|article|paper|all)
   --export-library      Export library (readwise+zotero) to public/data/library.json
   --export-now          Export now queue to public/data/now.json
+  --full                Ignore saved sync state and fetch all Readwise/Zotero records
+  --since ISO_DATE      Override Readwise incremental start timestamp
   -h, --help            Show this help
 
 Examples:
-  bun sync local              # fast, no API calls
-  bun sync api                # slow, hits Readwise + Zotero + Letterboxd + RAWG APIs
-  bun sync readwise           # just Readwise
-  bun sync letterboxd         # just Letterboxd
-  bun sync --stats            # show what's in the DB
-  bun sync --export-library   # regenerate library.json for Astro build
+  bun sync local                         # fast, no API calls
+  bun sync api --export-library          # sync APIs, then regenerate library.json
+  bun sync readwise                      # incremental Readwise sync after first successful run
+  bun sync readwise --full               # full Readwise backfill
+  bun sync readwise --since 2026-04-01   # Readwise changes since a timestamp/date
+  bun sync zotero                        # incremental Zotero sync after first successful run
+  bun sync letterboxd                    # just Letterboxd
+  bun sync --stats                       # show what's in the DB
+  bun sync --export-library              # export only, no sync
 `);
 }
 
@@ -1021,6 +1352,8 @@ async function main() {
 	}
 
 	const db = getDb();
+	const hasCommand = positionals.length > 0;
+	const command = positionals[0] || "all";
 
 	if (values.stats) {
 		console.log("📊 Database stats:");
@@ -1037,79 +1370,22 @@ async function main() {
 		return;
 	}
 
-	if (values["export-library"]) {
-		const resources = getLibraryResources(db);
-
-		// Transform to frontend format (snake_case → camelCase)
-		const frontendResources = resources.map((r) => ({
-			id: r.id,
-			source: r.source,
-			type: r.type,
-			title: r.title,
-			url: r.url || "",
-			author: r.author || null,
-			description: r.description || null,
-			dateAdded: r.created_at || new Date().toISOString(),
-			datePublished: r.date_published || null,
-			tags: r.tags || [],
-			imageUrl: r.image_url || null,
-			readingProgress: r.reading_progress,
-			itemType: r.item_type,
-			publicationTitle: r.publication_title,
-		}));
-
-		const output = {
-			fetchedAt: new Date().toISOString(),
-			resources: frontendResources,
-		};
-
-		const outputPath = "./public/data/library.json";
-		writeFileSync(outputPath, JSON.stringify(output, null, 2));
-		console.log(
-			`📚 Exported ${resources.length} library resources to ${outputPath}`,
-		);
+	if (values["export-library"] && !hasCommand) {
+		exportLibrary(db);
 		db.close();
 		return;
 	}
 
-	if (values["export-now"]) {
-		const resources = getNowResources(db);
-
-		// Transform to frontend format
-		const frontendResources = resources.map((r) => ({
-			id: r.id,
-			source: r.source,
-			type: r.type,
-			title: r.title,
-			url: r.url || "",
-			author: r.author || null,
-			description: r.description || null,
-			imageUrl: r.image_url || null,
-			status: r.status,
-			queuePriority: r.queue_priority,
-			platformStatus: r.platform_status,
-			favorited: r.favorited === 1,
-			rating: r.rating || null,
-		}));
-
-		const output = {
-			exportedAt: new Date().toISOString(),
-			resources: frontendResources,
-		};
-
-		const outputPath = "./public/data/now.json";
-		writeFileSync(outputPath, JSON.stringify(output, null, 2));
-		console.log(
-			`🎯 Exported ${resources.length} now queue resources to ${outputPath}`,
-		);
+	if (values["export-now"] && !hasCommand) {
+		exportNow(db);
 		db.close();
 		return;
 	}
-
-	const command = positionals[0] || "all";
 
 	console.log("🔄 Starting sync...\n");
 
+	const fullSync = values.full === true;
+	const since = typeof values.since === "string" ? values.since : undefined;
 	let total = 0;
 
 	switch (command) {
@@ -1123,10 +1399,10 @@ async function main() {
 			break;
 		}
 		case "api": {
-			const rwCount = await syncReadwise(db);
+			const rwCount = await syncReadwise(db, { full: fullSync, since });
 			console.log(`✅ Readwise: ${rwCount} synced`);
 			total += rwCount;
-			const zotCount = await syncZotero(db);
+			const zotCount = await syncZotero(db, { full: fullSync });
 			console.log(`✅ Zotero: ${zotCount} synced`);
 			total += zotCount;
 			const lbCount = await syncLetterboxd(db);
@@ -1144,10 +1420,10 @@ async function main() {
 			const musicCount = await syncMusic(db);
 			console.log(`✅ Music: ${musicCount} synced`);
 			total += musicCount;
-			const rwCount = await syncReadwise(db);
+			const rwCount = await syncReadwise(db, { full: fullSync, since });
 			console.log(`✅ Readwise: ${rwCount} synced`);
 			total += rwCount;
-			const zotCount = await syncZotero(db);
+			const zotCount = await syncZotero(db, { full: fullSync });
 			console.log(`✅ Zotero: ${zotCount} synced`);
 			total += zotCount;
 			const lbCount = await syncLetterboxd(db);
@@ -1169,12 +1445,12 @@ async function main() {
 			break;
 		}
 		case "readwise": {
-			total = await syncReadwise(db);
+			total = await syncReadwise(db, { full: fullSync, since });
 			console.log(`✅ Readwise: ${total} synced`);
 			break;
 		}
 		case "zotero": {
-			total = await syncZotero(db);
+			total = await syncZotero(db, { full: fullSync });
 			console.log(`✅ Zotero: ${total} synced`);
 			break;
 		}
@@ -1243,8 +1519,19 @@ async function main() {
 			printHelp();
 	}
 
+	if (values["export-library"]) {
+		exportLibrary(db);
+	}
+	if (values["export-now"]) {
+		exportNow(db);
+	}
+
 	console.log(`\n📊 Total: ${total} resources synced`);
 	db.close();
 }
 
-main();
+main().catch((error) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(`\n❌ Sync failed: ${message}`);
+	process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add persistent Readwise/Zotero sync state for incremental syncs
- process Readwise and Zotero page-by-page with per-page transactions, progress logs, retries, request timeouts, and rate-limit handling
- persist source metadata fields used by library export (source-added dates, reading progress, Zotero item/publication fields)
- add atomic library/now JSON exports and support post-sync export flags like `bun sync api --export-library`
- improve Zotero PDF classification and creator fallback handling

## Validation
- `bun lint`
- `bun run check`
- `bun run build`
- `bun sync zotero --full --export-library`
- `bun sync zotero`
- `bun sync readwise --since 2999-01-01T00:00:00Z --export-library`
- `bun sync readwise --export-library`
- `bun sync --stats`