### PR TITLE
feat: add blog typography system

### DIFF
--- a/docs/design/books-aesthetic.md
+++ b/docs/design/books-aesthetic.md
@@ -24,6 +24,7 @@ For this site, translate that inspiration into a more minimal personal-library l
 - **blue-native**: stay close to the existing blue theme rather than adding a new palette
 - **restrained surfaces**: thin borders, subtle translucency, minimal shadow
 - **text as interface**: numbered lists, small labels, and quiet metadata over large cards
+- **literary typography**: serif for page titles, intros, and touchstone notes; sans for controls and dense browsing
 
 ## What to avoid
 
@@ -60,20 +61,29 @@ They can be good internal prompts, but they quickly make the UI feel too big if 
 
 ## `/books` implementation notes
 
-The current `/books` experiment keeps the normal site width and uses three simple sections:
+The current `/books` experiment keeps the normal site width and uses four simple sections:
 
 1. intro with tiny stats
-2. favorites as a restrained numbered list
-3. full Goodreads index via `BookExplorer`
+2. currently open books as a small thread list
+3. favorites as a restrained numbered list with short notes
+4. full Goodreads index via `BookExplorer`
 
 `BookExplorer` should remain functional and familiar. Style changes should soften it, not hide its utility.
+
+## Typography direction
+
+The site now uses a two-font system:
+
+- **Instrument Sans** for the default UI layer: navigation, filters, metadata, dense index controls.
+- **Newsreader** for the literary layer: `/books` headings, intro copy, book titles, and touchstone notes.
+
+Use the serif sparingly. It should make reading feel warmer without turning every control into a manuscript.
 
 ## Future ideas
 
 Small next steps that fit the direction:
 
-- add a short note field to favorites explaining why each book matters
 - group favorites by theme only if the list grows
-- add one subtle typographic marker for “currently reading”
+- add a one-line “why now” note to currently open books if the data source supports it
 - bring a similar quiet archive language to `/library` later
 - consider a dedicated `/reading` or `/shelf` view only if `/books` starts carrying too much

--- a/src/components/BookExplorer.tsx
+++ b/src/components/BookExplorer.tsx
@@ -242,30 +242,36 @@ export default function BookExplorer({ books }: Props) {
 
 			{/* Stats Panel */}
 			{showStats && (
-				<div class="space-y-4 rounded-2xl border border-blue-900/10 bg-white/25 p-4 dark:border-blue-100/10 dark:bg-blue-950/15">
+				<div class="space-y-5 rounded-2xl border border-blue-900/10 bg-white/20 p-4 dark:border-blue-100/10 dark:bg-blue-950/10">
 					{/* Rating Distribution */}
 					<div>
-						<h3 class="font-semibold text-lg mb-2">My Ratings</h3>
-						<div class="flex items-end gap-2 h-20">
+						<h3 class="mb-2 text-sm font-medium text-blue-950 dark:text-blue-50">
+							My Ratings
+						</h3>
+						<div class="flex h-20 items-end gap-2">
 							{stats.ratingDistribution.map((count, i) => {
 								const maxCount = Math.max(...stats.ratingDistribution, 1);
 								const height = (count / maxCount) * 100;
 								return (
-									<div key={i} class="flex-1 flex flex-col items-center gap-1">
+									<div key={i} class="flex flex-1 flex-col items-center gap-1">
 										<div
-											class="w-full bg-yellow-400 rounded-t"
+											class="w-full rounded-t bg-blue-500/35 dark:bg-blue-300/35"
 											style={{
 												height: `${height}%`,
 												minHeight: count > 0 ? "4px" : "0",
 											}}
 										/>
-										<span class="text-xs text-gray-500">{i + 1}★</span>
-										<span class="text-xs text-gray-400">{count}</span>
+										<span class="text-xs text-blue-900/55 dark:text-blue-100/50">
+											{i + 1}★
+										</span>
+										<span class="text-xs tabular-nums text-blue-900/45 dark:text-blue-100/40">
+											{count}
+										</span>
 									</div>
 								);
 							})}
 						</div>
-						<p class="text-xs text-gray-500 mt-2">
+						<p class="mt-2 text-xs tabular-nums text-blue-900/55 dark:text-blue-100/50">
 							Avg: {stats.avgMyRating.toFixed(1)}★ (Goodreads avg:{" "}
 							{stats.avgGoodreadsRating.toFixed(2)})
 						</p>
@@ -273,16 +279,18 @@ export default function BookExplorer({ books }: Props) {
 
 					{/* Top Authors */}
 					<div>
-						<h3 class="font-semibold text-lg mb-2">Top Authors</h3>
-						<div class="grid grid-cols-2 sm:grid-cols-5 gap-2">
+						<h3 class="mb-2 text-sm font-medium text-blue-950 dark:text-blue-50">
+							Top Authors
+						</h3>
+						<div class="grid grid-cols-2 gap-2 sm:grid-cols-5">
 							{stats.topAuthors.slice(0, 10).map((author) => (
 								<div
 									key={author.name}
-									class="text-sm px-2 py-1 rounded bg-white dark:bg-gray-700 truncate"
+									class="truncate rounded border border-blue-900/10 bg-white/25 px-2 py-1 text-sm dark:border-blue-100/10 dark:bg-blue-950/15"
 									title={author.name}
 								>
 									<span class="font-medium">{author.name}</span>
-									<span class="text-gray-500 dark:text-gray-400 ml-1">
+									<span class="ml-1 tabular-nums text-blue-900/50 dark:text-blue-100/45">
 										({author.count})
 									</span>
 								</div>
@@ -292,20 +300,24 @@ export default function BookExplorer({ books }: Props) {
 
 					{/* By Decade */}
 					<div>
-						<h3 class="font-semibold text-lg mb-2">By Decade</h3>
+						<h3 class="mb-2 text-sm font-medium text-blue-950 dark:text-blue-50">
+							By Decade
+						</h3>
 						<div class="space-y-1">
 							{stats.decadeBreakdown.map((d) => {
 								const percentage = (d.count / stats.totalBooks) * 100;
 								return (
 									<div key={d.decade} class="flex items-center gap-2">
-										<span class="text-sm w-14">{d.decade}</span>
-										<div class="flex-1 h-4 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden">
+										<span class="w-14 text-sm text-blue-900/65 dark:text-blue-100/60">
+											{d.decade}
+										</span>
+										<div class="h-4 flex-1 overflow-hidden rounded bg-blue-500/10 dark:bg-blue-100/10">
 											<div
-												class={`h-full ${DECADE_COLORS[d.decade]?.split(" ")[0] || "bg-gray-500"}`}
+												class={`h-full ${DECADE_COLORS[d.decade]?.split(" ")[0] || "bg-blue-500/35"}`}
 												style={{ width: `${percentage}%` }}
 											/>
 										</div>
-										<span class="text-sm text-gray-500 w-16 text-right">
+										<span class="w-16 text-right text-sm tabular-nums text-blue-900/55 dark:text-blue-100/50">
 											{d.count} ({percentage.toFixed(0)}%)
 										</span>
 									</div>
@@ -317,14 +329,19 @@ export default function BookExplorer({ books }: Props) {
 					{/* Recommenders */}
 					{stats.topRecommenders.length > 0 && (
 						<div>
-							<h3 class="font-semibold text-lg mb-2">Recommended By</h3>
+							<h3 class="mb-2 text-sm font-medium text-blue-950 dark:text-blue-50">
+								Recommended By
+							</h3>
 							<div class="flex flex-wrap gap-2">
 								{stats.topRecommenders.map((rec) => (
 									<span
 										key={rec.name}
-										class="text-sm px-2 py-1 rounded bg-white dark:bg-gray-700"
+										class="rounded border border-blue-900/10 bg-white/25 px-2 py-1 text-sm dark:border-blue-100/10 dark:bg-blue-950/15"
 									>
-										{rec.name} <span class="text-gray-500">({rec.count})</span>
+										{rec.name}{" "}
+										<span class="tabular-nums text-blue-900/50 dark:text-blue-100/45">
+											({rec.count})
+										</span>
 									</span>
 								))}
 							</div>
@@ -441,7 +458,7 @@ export default function BookExplorer({ books }: Props) {
 				<button
 					type="button"
 					onClick={clearFilters}
-					class="text-xs text-red-500 hover:text-red-400"
+					class="text-xs text-blue-900/55 hover:text-blue-900 dark:text-blue-100/50 dark:hover:text-blue-100"
 				>
 					Clear filters
 				</button>
@@ -491,7 +508,7 @@ export default function BookExplorer({ books }: Props) {
 
 			{/* Book List */}
 			<div class="space-y-1">
-				<div class="flex items-center gap-2 mb-2">
+				<div class="mb-2 flex items-center gap-2">
 					<button
 						type="button"
 						onClick={selectAllVisible}
@@ -503,7 +520,7 @@ export default function BookExplorer({ books }: Props) {
 						<button
 							type="button"
 							onClick={clearSelection}
-							class="text-xs text-red-500 hover:text-red-400"
+							class="text-xs text-blue-900/55 hover:text-blue-900 dark:text-blue-100/50 dark:hover:text-blue-100"
 						>
 							Clear selection ({selectedIds.size})
 						</button>
@@ -518,12 +535,13 @@ export default function BookExplorer({ books }: Props) {
 						}`}
 					>
 						<input
+							aria-label={`Select ${book.title}`}
 							type="checkbox"
 							checked={selectedIds.has(book.id)}
 							onChange={() => toggleSelection(book.id)}
-							class="w-4 h-4 rounded border-gray-300 dark:border-gray-600"
+							class="size-4 rounded border-blue-900/20 text-blue-700 dark:border-blue-100/20"
 						/>
-						<div class="flex-1 min-w-0">
+						<div class="min-w-0 flex-1">
 							<div class="flex items-center gap-2">
 								<a
 									href={book.amazonSearchUrl}
@@ -535,7 +553,7 @@ export default function BookExplorer({ books }: Props) {
 								</a>
 								{book.myRating > 0 && <StarRating rating={book.myRating} />}
 							</div>
-							<div class="text-sm text-gray-500 dark:text-gray-400 truncate">
+							<div class="truncate text-sm text-blue-900/58 dark:text-blue-100/55">
 								{book.author}
 								{book.recommender && (
 									<span class="ml-2 text-blue-900/60 dark:text-blue-100/55">
@@ -544,10 +562,10 @@ export default function BookExplorer({ books }: Props) {
 								)}
 							</div>
 						</div>
-						<div class="hidden sm:block text-xs text-gray-400 dark:text-gray-500 w-12 text-right">
+						<div class="hidden w-12 text-right text-xs tabular-nums text-blue-900/42 dark:text-blue-100/40 sm:block">
 							{book.pages > 0 ? `${book.pages}p` : ""}
 						</div>
-						<div class="text-xs text-gray-400 dark:text-gray-500 w-12 text-right">
+						<div class="w-12 text-right text-xs tabular-nums text-blue-900/42 dark:text-blue-100/40">
 							{book.yearPublished || ""}
 						</div>
 						<span
@@ -570,7 +588,7 @@ export default function BookExplorer({ books }: Props) {
 						type="button"
 						onClick={() => setPage((p) => Math.max(0, p - 1))}
 						disabled={page === 0}
-						class="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+						class="rounded border border-blue-900/10 px-3 py-1 hover:bg-white/25 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-100/10 dark:hover:bg-blue-950/20"
 					>
 						Previous
 					</button>
@@ -581,7 +599,7 @@ export default function BookExplorer({ books }: Props) {
 						type="button"
 						onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
 						disabled={page >= totalPages - 1}
-						class="px-3 py-1 rounded border border-gray-300 dark:border-gray-600 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-100 dark:hover:bg-gray-800"
+						class="rounded border border-blue-900/10 px-3 py-1 hover:bg-white/25 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-100/10 dark:hover:bg-blue-950/20"
 					>
 						Next
 					</button>
@@ -590,11 +608,11 @@ export default function BookExplorer({ books }: Props) {
 
 			{/* Selection Panel */}
 			{selectedIds.size > 0 && (
-				<div class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 w-11/12 max-w-2xl -translate-x-1/2 rounded-2xl border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-800 dark:bg-slate-950">
-					<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+				<div class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] left-1/2 w-11/12 max-w-2xl -translate-x-1/2 rounded-2xl border border-blue-900/10 bg-white p-4 shadow-lg dark:border-blue-100/10 dark:bg-blue-950">
+					<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 						<div>
 							<p class="font-medium">{selectedIds.size} books selected</p>
-							<p class="text-sm text-gray-500 dark:text-gray-400">
+							<p class="text-sm tabular-nums text-blue-900/60 dark:text-blue-100/55">
 								{selectedBooks
 									.reduce((sum, b) => sum + b.pages, 0)
 									.toLocaleString()}{" "}
@@ -607,10 +625,10 @@ export default function BookExplorer({ books }: Props) {
 								onClick={() =>
 									copyToClipboard(exportAsJson(selectedBooks), "JSON")
 								}
-								class={`text-xs px-3 py-1 rounded border ${
+								class={`rounded border px-3 py-1 text-xs ${
 									copySuccess === "JSON"
-										? "bg-green-500/20 text-green-400 border-green-500/30"
-										: "border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+										? "border-blue-500/30 bg-blue-500/15 text-blue-900 dark:text-blue-100"
+										: "border-blue-900/10 hover:bg-white/25 dark:border-blue-100/10 dark:hover:bg-blue-950/20"
 								}`}
 							>
 								{copySuccess === "JSON" ? "Copied!" : "Copy JSON"}
@@ -620,10 +638,10 @@ export default function BookExplorer({ books }: Props) {
 								onClick={() =>
 									copyToClipboard(exportAsText(selectedBooks), "Text")
 								}
-								class={`text-xs px-3 py-1 rounded border ${
+								class={`rounded border px-3 py-1 text-xs ${
 									copySuccess === "Text"
-										? "bg-green-500/20 text-green-400 border-green-500/30"
-										: "border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800"
+										? "border-blue-500/30 bg-blue-500/15 text-blue-900 dark:text-blue-100"
+										: "border-blue-900/10 hover:bg-white/25 dark:border-blue-100/10 dark:hover:bg-blue-950/20"
 								}`}
 							>
 								{copySuccess === "Text" ? "Copied!" : "Copy List"}
@@ -631,7 +649,7 @@ export default function BookExplorer({ books }: Props) {
 							<button
 								type="button"
 								onClick={clearSelection}
-								class="text-xs px-3 py-1 rounded border border-red-500/30 text-red-500 hover:bg-red-500/10"
+								class="rounded border border-blue-900/10 px-3 py-1 text-xs text-blue-900/65 hover:bg-white/25 dark:border-blue-100/10 dark:text-blue-100/60 dark:hover:bg-blue-950/20"
 							>
 								Clear
 							</button>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,9 @@ const { pageTitle = "Welcome to my mind... 🌊" } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&family=Newsreader:opsz,wght@6..72,400..700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>

--- a/src/pages/books.astro
+++ b/src/pages/books.astro
@@ -11,50 +11,59 @@ const favoriteBooks = [
 	{
 		title: "Wanting",
 		author: "Luke Burgis",
+		note: "Desire as weather: borrowed, contagious, worth noticing.",
 		amazonLink:
 			"https://www.amazon.com/Wanting-Power-Mimetic-Desire-Everyday/dp/1250262488/",
 	},
 	{
 		title: "Meditations (t. by Gregory Hays)",
 		author: "Marcus Aurelius",
+		note: "Portable discipline for returning attention to what can be carried.",
 		amazonLink: "https://www.amazon.com/Meditations-Marcus-Aurelius/dp/0812968255/",
 	},
 	{
 		title: "Thinking in Systems",
 		author: "Donella H. Meadows",
+		note: "Feedback loops, leverage points, and patience with complexity.",
 		amazonLink:
 			"https://www.amazon.com/Thinking-Systems-Donella-H-Meadows/dp/1603580557/",
 	},
 	{
 		title: "The Evolving Self",
 		author: "Robert Kegan",
+		note: "A map for how the self keeps outgrowing its container.",
 		amazonLink:
 			"https://www.amazon.com/Evolving-Self-Problem-Process-Development/dp/0674272315/",
 	},
 	{
 		title: "Range",
 		author: "David Epstein",
+		note: "Permission to roam, sample, and let breadth compound.",
 		amazonLink:
 			"https://www.amazon.com/Range-Generalists-Triumph-Specialized-World/dp/0735214484/",
 	},
 	{
 		title: "Gödel, Escher, Bach",
 		author: "Douglas Hofstadter",
+		note: "Strange loops as a reminder that play can be rigorous.",
 		amazonLink: "https://a.co/d/4khX6GJ",
 	},
 	{
 		title: "Siddhartha",
 		author: "Hermann Hesse",
+		note: "A short river-book about listening before naming.",
 		amazonLink: "https://a.co/d/3P4MyJW",
 	},
 	{
 		title: "The Creative Act",
 		author: "Rick Rubin",
+		note: "Practice as receptivity: make the conditions, then get quiet.",
 		amazonLink: "https://a.co/d/3P4MyJW",
 	},
 	{
 		title: "The Upanishads",
 		author: "Eknath Easwaran (translator)",
+		note: "Ancient negative space around self, attention, and the real.",
 		amazonLink:
 			"https://www.amazon.com/Upanishads-Easwarans-Classics-Indian-Spirituality/dp/1586380214/",
 	},
@@ -62,6 +71,9 @@ const favoriteBooks = [
 
 const books = parseGoodreadsData(csvText);
 const stats = computeStats(books);
+const currentReadingBooks = books
+	.filter((book) => book.exclusiveShelf === "currently-reading")
+	.slice(0, 5);
 const shelfStats = [
 	["read", stats.booksRead],
 	["reading", stats.currentlyReading],
@@ -73,10 +85,10 @@ const shelfStats = [
 <BaseLayout pageTitle={pageTitle}>
 	<section class="mb-10 border-b border-blue-900/10 pb-8 dark:border-blue-100/10">
 		<p class="mb-3 text-sm text-blue-700/80 dark:text-blue-200/70">/books</p>
-		<h1 class="text-balance text-4xl font-semibold text-blue-950 dark:text-blue-50">
+		<h1 class="text-balance font-serif text-4xl font-medium text-blue-950 dark:text-blue-50">
 			{pageTitle}
 		</h1>
-		<p class="mt-4 max-w-xl text-pretty text-blue-900/75 dark:text-blue-100/75">
+		<p class="mt-4 max-w-xl text-pretty font-serif text-lg text-blue-900/75 dark:text-blue-100/75">
 			{pageDescription}. A quiet shelf of touchstones, open loops, and books I keep returning to.
 		</p>
 
@@ -92,13 +104,54 @@ const shelfStats = [
 		</dl>
 	</section>
 
+	{currentReadingBooks.length > 0 && (
+		<section aria-labelledby="currently-open-title" class="mb-12">
+			<div class="mb-4 flex items-baseline justify-between gap-4">
+				<h2 id="currently-open-title" class="text-balance font-serif text-xl font-medium text-blue-950 dark:text-blue-50">
+					Currently open
+				</h2>
+				<p class="text-xs tabular-nums text-blue-800/60 dark:text-blue-100/50">
+					{currentReadingBooks.length} threads
+				</p>
+			</div>
+
+			<ol class="divide-y divide-blue-900/10 rounded-2xl border border-blue-900/10 bg-white/20 dark:divide-blue-100/10 dark:border-blue-100/10 dark:bg-blue-950/10">
+				{currentReadingBooks.map((book) => (
+					<li>
+						<a
+							href={book.amazonSearchUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="group grid grid-cols-[2rem_1fr_auto] items-center gap-3 px-4 py-3 transition-colors hover:bg-white/25 dark:hover:bg-blue-950/25"
+						>
+							<span class="text-center text-sm text-blue-700/55 dark:text-blue-200/45" aria-hidden="true">
+								◌
+							</span>
+							<span class="min-w-0">
+								<span class="block truncate font-serif text-lg font-medium text-blue-950 group-hover:text-blue-700 dark:text-blue-50 dark:group-hover:text-blue-200">
+									{book.title}
+								</span>
+								<span class="mt-0.5 block truncate text-sm text-blue-900/60 dark:text-blue-100/55">
+									{book.author}
+								</span>
+							</span>
+							<span class="hidden text-xs tabular-nums text-blue-800/45 dark:text-blue-100/40 sm:block">
+								{book.pages > 0 ? `${book.pages}p` : "open"}
+							</span>
+						</a>
+					</li>
+				))}
+			</ol>
+		</section>
+	)}
+
 	<section aria-labelledby="favorites-title" class="mb-12">
 		<div class="mb-4 flex items-baseline justify-between gap-4">
-			<h2 id="favorites-title" class="text-balance text-xl font-semibold text-blue-950 dark:text-blue-50">
+			<h2 id="favorites-title" class="text-balance font-serif text-xl font-medium text-blue-950 dark:text-blue-50">
 				Favorites
 			</h2>
 			<p class="text-xs tabular-nums text-blue-800/60 dark:text-blue-100/50">
-				{favoriteBooks.length} notes
+				{favoriteBooks.length} touchstones
 			</p>
 		</div>
 
@@ -115,11 +168,14 @@ const shelfStats = [
 							{String(index + 1).padStart(2, "0")}
 						</span>
 						<span>
-							<span class="block text-pretty font-medium text-blue-950 group-hover:text-blue-700 dark:text-blue-50 dark:group-hover:text-blue-200">
+							<span class="block text-pretty font-serif text-lg font-medium text-blue-950 group-hover:text-blue-700 dark:text-blue-50 dark:group-hover:text-blue-200">
 								{book.title}
 							</span>
 							<span class="mt-0.5 block text-sm text-blue-900/60 dark:text-blue-100/55">
 								{book.author}
+							</span>
+							<span class="mt-2 block text-pretty font-serif text-base text-blue-900/70 dark:text-blue-100/65">
+								{book.note}
 							</span>
 						</span>
 					</a>
@@ -130,7 +186,7 @@ const shelfStats = [
 
 	<section aria-labelledby="index-title">
 		<div class="mb-4">
-			<h2 id="index-title" class="text-balance text-xl font-semibold text-blue-950 dark:text-blue-50">
+			<h2 id="index-title" class="text-balance font-serif text-xl font-medium text-blue-950 dark:text-blue-50">
 				Index
 			</h2>
 			<p class="mt-1 text-pretty text-sm text-blue-900/65 dark:text-blue-100/60">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,9 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
+	--font-sans: "Instrument Sans", ui-sans-serif, system-ui, sans-serif;
+	--font-serif: "Newsreader", ui-serif, Georgia, Cambria, serif;
+
 	--animate-fade-in: fade-in 0.5s ease-in-out;
 	--animate-slide-in: slide-in 0.5s ease-in-out;
 
@@ -71,8 +74,13 @@
 
 body {
 	@apply bg-linear-to-b from-blue-100 to-blue-200 dark:from-blue-900 dark:to-blue-950;
-	@apply text-blue-900 dark:text-blue-100;
+	@apply font-sans text-blue-900 antialiased dark:text-blue-100;
 	@apply min-h-screen transition-colors duration-300;
+	font-feature-settings:
+		"kern" 1,
+		"liga" 1,
+		"calt" 1;
+	text-rendering: optimizeLegibility;
 }
 
 ::selection {


### PR DESCRIPTION
## Summary
- add Instrument Sans + Newsreader as the blog typography pair
- apply the serif layer to the /books literary surfaces while keeping dense controls sans
- refine the books archive details and document the typography direction

## Verification
- bun lint
- bun run build