### PR TITLE
feat(homepage): twilight atmosphere

### DIFF
--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -2,7 +2,11 @@
 const { title, url, date } = Astro.props;
 ---
 
-<li class="mb-2">
-    <a href={url} class="text-blue-600 hover:underline">{title}</a>
-    {date && <span class="text-sm text-gray-500 ml-2">— {date}</span>}
-  </li>
+<li>
+	<a href={url} class="group block">
+		<span class="font-medium text-slate-800 group-hover:text-blue-600 dark:text-slate-200 dark:group-hover:text-sky-400 transition-colors duration-200">
+			{title}
+		</span>
+		{date && <span class="text-sm text-slate-400 dark:text-slate-500 ml-2">— {date}</span>}
+	</a>
+</li>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -12,20 +12,20 @@ const currentPath = pathname.slice(1); // remove the leading slash
     { path: 'music', label: 'Music' },
     { path: 'about', label: 'About' }
   ].map(({ path, label }) => (
-    <a 
-      href={`/${path}`} 
+    <a
+      href={`/${path}`}
       class:list={[
         "relative py-1.5 px-1",
         "transition-colors duration-300",
-        "hover:text-blue-600 dark:hover:text-blue-300",
-        "text-blue-700 dark:text-blue-200",
+        "hover:text-blue-600 dark:hover:text-sky-400",
+        "text-slate-600 dark:text-slate-300",
         // Active state
-        currentPath === path ? "active" : ""
+        currentPath === path ? "active font-medium text-slate-900 dark:text-slate-100" : ""
       ]}
     >
       {label}
       {currentPath === path && (
-        <span class="absolute bottom-0 left-0 w-full h-0.5 bg-blue-600 dark:bg-blue-400 
+        <span class="absolute bottom-0 left-0 w-full h-0.5 bg-blue-500 dark:bg-sky-400
           transform origin-left animate-[width] duration-300"></span>
       )}
     </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,47 +18,70 @@ const latestDepths = depthPosts
   .slice(0, 3);
 ---
 <BaseLayout pageTitle={pageTitle}>
-	<h1 class="text-4xl font-bold mb-4">{pageTitle}</h1>
+	<section class="mb-12 pt-4">
+		<h1 class="font-serif text-5xl font-medium leading-tight text-slate-900 dark:text-slate-50 mb-6">
+			Welcome to my mind... <span class="inline-block">🌊</span>
+		</h1>
 
-	<p class="mb-6">Hey, I'm Divesh. Born in Panama to Indian-Colombian parents, now living in San Francisco after studying in Boston.</p>
+		<p class="font-serif text-lg text-slate-600 dark:text-slate-300 leading-relaxed max-w-2xl">
+			Hey, I'm Divesh. Born in Panama to Indian-Colombian parents, now building
+			<a href="https://versa.so" class="link-accent">Versa</a> at the edge of
+			peer-to-peer commerce and AI agents. I think about systems, decentralization,
+			incentives, and games.
+		</p>
+	</section>
 
-	<p class="mb-6">I think about systems, decentralization, incentives, and games. Building <a href="https://versa.so" class="text-sky-400 hover:text-sky-300">Versa</a> to enable peer-to-peer commerce with AI agents that automate sales and increase discovery in Latin America.</p>
-
-	<p class="mb-6">Capturing my stream of consciousness on <a href="/waves" class="text-sky-400 hover:text-sky-300">Waves</a> and deeper explorations on <a href="/depths" class="text-sky-400 hover:text-sky-300">Depths</a>.</p>
-
-	<p class="mb-4">Some of my earlier writings:</p>
-	<ul class="list-disc pl-6 mb-6 space-y-2">
-		<li><a href="https://mirror.xyz/steeldao.eth/bg3vMQYjPFddZkKtWaGe8zYg4w6H3VCRq7l3oqVSyd8" class="text-sky-400 hover:text-sky-300">Blockchain: A Catalyst for Open-Source AI</a></li>
-		<li><a href="https://www.bvp.com/news/building-the-web3-ecosystem-of-the-future" class="text-sky-400 hover:text-sky-300">Launching Steel DAO</a></li>
-		<li><a href="https://www.bvp.com/atlas/are-zero-knowledge-proofs-zkps-the-future-of-blockchain" class="text-sky-400 hover:text-sky-300">Are ZKPs the Future of Blockchain?</a></li>
-	</ul>
-
-	<div class="grid grid-cols-1 md:grid-cols-2 gap-8 my-12">
-		<section>
-			<h2 class="text-2xl font-bold mb-4">Waves</h2>
-			<ul class="space-y-4">
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-12">
+		<section class="surface p-6">
+			<div class="flex items-baseline justify-between mb-4">
+				<h2 class="font-serif text-2xl font-medium text-slate-900 dark:text-slate-50">Waves</h2>
+				<span class="text-xs text-slate-400 dark:text-slate-500 uppercase tracking-wider">Stream</span>
+			</div>
+			<ul class="space-y-3">
 				{latestWaves.map((post) => (
 					<BlogPost
 						url={`/waves/${post.id}`}
 						title={post.data.title}
-						date={new Date(post.data.pubDate).toLocaleDateString('en-US', { month: 'short', year: '2-digit'})}
+						date={new Date(post.data.pubDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
 					/>
 				))}
 			</ul>
-			<a href="/waves" class="inline-block mt-4 text-sky-400 hover:text-sky-300">View all waves →</a>
+			<a href="/waves" class="inline-block mt-4 text-sm link-accent">View all waves →</a>
 		</section>
 
-		<section>
-			<h2 class="text-2xl font-bold mb-4">Depths</h2>
-			<ul class="space-y-4">
+		<section class="surface p-6">
+			<div class="flex items-baseline justify-between mb-4">
+				<h2 class="font-serif text-2xl font-medium text-slate-900 dark:text-slate-50">Depths</h2>
+				<span class="text-xs text-slate-400 dark:text-slate-500 uppercase tracking-wider">Essays</span>
+			</div>
+			<ul class="space-y-3">
 				{latestDepths.map((post) => (
 					<BlogPost
 						url={`/depths/${post.id}`}
 						title={post.data.title}
-						date={new Date(post.data.pubDate).toLocaleDateString('en-US', { month: 'short', year: 'numeric'})}
+						date={new Date(post.data.pubDate).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
 					/>
 				))}
 			</ul>
-			<a href="/depths" class="inline-block mt-4 text-sky-400 hover:text-sky-300">View all depths →</a>
+			<a href="/depths" class="inline-block mt-4 text-sm link-accent">View all depths →</a>
 		</section>
+	</div>
+
+	<section class="surface p-6 mb-12">
+		<h2 class="font-serif text-xl font-medium text-slate-900 dark:text-slate-50 mb-4">Earlier writings</h2>
+		<ul class="space-y-3">
+			<li class="flex items-baseline gap-2">
+				<a href="https://mirror.xyz/steeldao.eth/bg3vMQYjPFddZkKtWaGe8zYg4w6H3VCRq7l3oqVSyd8" class="link-accent">Blockchain: A Catalyst for Open-Source AI</a>
+				<span class="text-sm text-slate-400 dark:text-slate-500">— Mirror</span>
+			</li>
+			<li class="flex items-baseline gap-2">
+				<a href="https://www.bvp.com/news/building-the-web3-ecosystem-of-the-future" class="link-accent">Launching Steel DAO</a>
+				<span class="text-sm text-slate-400 dark:text-slate-500">— BVP</span>
+			</li>
+			<li class="flex items-baseline gap-2">
+				<a href="https://www.bvp.com/atlas/are-zero-knowledge-proofs-zkps-the-future-of-blockchain" class="link-accent">Are ZKPs the Future of Blockchain?</a>
+				<span class="text-sm text-slate-400 dark:text-slate-500">— BVP</span>
+			</li>
+		</ul>
+	</section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,16 +73,56 @@
 }
 
 body {
-	@apply bg-linear-to-b from-blue-100 to-blue-200 dark:from-blue-900 dark:to-blue-950;
-	@apply font-sans text-blue-900 antialiased dark:text-blue-100;
-	@apply min-h-screen transition-colors duration-300;
+	@apply font-sans text-slate-800 antialiased dark:text-slate-200;
+	@apply min-h-screen transition-colors duration-500;
 	font-feature-settings:
 		"kern" 1,
 		"liga" 1,
 		"calt" 1;
 	text-rendering: optimizeLegibility;
+	background:
+		radial-gradient(
+			ellipse 80% 50% at 50% -10%,
+			rgba(191, 219, 254, 0.3),
+			transparent
+		),
+		linear-gradient(180deg, #f0f5fa 0%, #e8eff7 30%, #dfeaf5 60%, #d6e3f0 100%);
+}
+
+.dark body {
+	background:
+		radial-gradient(
+			ellipse 80% 50% at 50% -10%,
+			rgba(30, 58, 138, 0.35),
+			transparent
+		),
+		linear-gradient(180deg, #0c1426 0%, #091225 30%, #060f1f 60%, #030a16 100%);
+}
+
+/* Subtle noise texture overlay */
+body::before {
+	content: "";
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	opacity: 0.025;
+	pointer-events: none;
+	z-index: 50;
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
 }
 
 ::selection {
-	background: rgba(56, 189, 248, 0.2);
+	background: rgba(56, 189, 248, 0.25);
+}
+
+/* Translucent card surface */
+.surface {
+	@apply rounded-2xl border border-blue-900/5 bg-white/30 backdrop-blur-sm dark:border-blue-100/5 dark:bg-blue-950/20;
+}
+
+/* Consistent link accent */
+.link-accent {
+	@apply text-blue-700 transition-colors duration-200 hover:text-blue-500 dark:text-sky-400 dark:hover:text-sky-300;
 }


### PR DESCRIPTION
Experimental direction for the homepage aesthetic.

What's here
- Layered radial-gradient + linear-gradient background instead of flat blue to blue
- Subtle SVG noise texture overlay at 2.5% opacity
- New .surface utility: translucent cards with backdrop-blur-sm that float over the water
- Serif (Newsreader) for page headings and bio — more journal-like
- Compressed bio to one paragraph, moved earlier writings into a card
- Consistent .link-accent utility across nav and links
- Nav tones shifted to slate, blue reserved for hover/active states

Spirits attempted
- Twilight / ocean depth as intentional mood, not default color choice
- Homepage content organized into floating cards instead of flat text sections
- Unified visual language with the Books page (which already used card surfaces)

Not married to all of it — pushed for review so you can see it rendered and decide what sticks. 🌊
