### PR TITLE
Add local-first divesh_zirp personal oracle v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Personal blog built with [Astro](https://astro.build).
 | `bun preview` | Preview build locally |
 | `bun sync api --export-library` | Sync Readwise/Zotero/etc. and export `/library` data |
 | `bun sync --stats` | Show local knowledge DB stats |
+| `bun zirp inventory` | Inventory the local `divesh_zirp` corpus |
+| `bun zirp search "games as training grounds"` | Search the personal oracle corpus |
+| `bun zirp ask "what should I write next?"` | Ask the oracle; uses Anthropic if configured, otherwise prints the prompt |
 
 ## Linting & Formatting
 
@@ -43,7 +46,10 @@ src/
 └── styles/          # Global CSS
 scripts/
 ├── db.ts            # SQLite knowledge base helpers
-└── sync.ts          # Sync/export CLI
+├── sync.ts          # Sync/export CLI
+└── zirp.ts          # Local-first personal oracle CLI
+docs/
+└── zirp/            # divesh_zirp architecture, persona docs, and PR notes
 public/
 └── data/            # Generated/static data files
 ```
@@ -79,6 +85,21 @@ Notes:
 - First Readwise sync can take several minutes for large libraries.
 - Later Readwise/Zotero runs are incremental via saved `sync_state` in `data/knowledge.db`.
 - `data/` and generated JSON exports are ignored; regenerate them locally.
+
+### Personal Oracle (`divesh_zirp`)
+
+A local-first personal oracle inspired by `vgr_zirp`. It retrieves from blog posts, selected notes, Versa context, Readwise/Zotero metadata, Goodreads, and Spotify, then composes grounded prompts using explicit persona docs in `docs/zirp/`.
+
+```bash
+bun zirp inventory
+bun zirp search "games as training grounds"
+bun zirp prompt "connect WoW, feedback loops, and Versa"
+bun zirp ask "what should I write next?"
+```
+
+Privacy defaults: `journal/` is excluded unless `--include-journal` is passed; API calls only happen when `ANTHROPIC_API_KEY` exists.
+
+See `docs/zirp/README.md` and `docs/zirp/ARCHITECTURE.md`.
 
 ## Content
 

--- a/docs/zirp/ARCHITECTURE.md
+++ b/docs/zirp/ARCHITECTURE.md
@@ -1,0 +1,60 @@
+# divesh_zirp v0
+
+`divesh_zirp` is a local-first personal oracle for Divesh's writing, taste, reading, and founder context. It borrows the `vgr_zirp` shape, but keeps v0 deliberately simple: no hosted vector database, no required API calls, and no journal indexing by default.
+
+## Goals
+
+- Retrieve grounded context from self-authored writing and taste data.
+- Answer in a Divesh-flavored voice without pretending to be omniscient.
+- Cite source paths/titles so outputs can be traced back.
+- Stay private-first: local corpus, optional LLM call only if an API key exists.
+
+## Corpus tiers
+
+| Tier | Sources | Weight | Notes |
+| --- | --- | ---: | --- |
+| 0 | Blog essays, waves, about page | 1.30 | Highest-signal self-authored public writing. |
+| 1 | Personal notes, root notes, selected resources | 1.15 | Private self-context and taste notes. `journal/` excluded by default. |
+| 2 | Versa strategy and sales notes | 1.05 | Operator/founder context. |
+| 3 | Readwise/Zotero resource metadata | 0.75 | What Divesh reads and saves. Uses title/author/description/tags. |
+| 4 | Goodreads CSV | 0.70 | Books read/to-read, ratings, shelves. |
+| 5 | Spotify playlist export | 0.55 | Taste signal, not a factual source. |
+
+## Current retrieval
+
+v0 uses weighted lexical retrieval:
+
+1. Load local corpus records.
+2. Tokenize query and documents.
+3. Score unique and repeated token matches.
+4. Add boosts for title matches and exact phrase matches.
+5. Multiply by source-tier weight.
+6. Return top sources with snippets.
+
+This is intentionally crude but useful. v1 should add embeddings with a local SQLite vector extension, LanceDB, or a hosted vector index.
+
+## Commands
+
+```bash
+bun zirp inventory
+bun zirp search "games as training grounds"
+bun zirp prompt "connect WoW, feedback loops, and Versa"
+bun zirp ask "what should I write next?"
+```
+
+`ask` calls Anthropic only if `ANTHROPIC_API_KEY` is present. Otherwise it prints the composed prompt for copy/paste into any model.
+
+## Privacy defaults
+
+- Does not index `journal/` unless `--include-journal` is passed.
+- Does not modify notes or source data.
+- Reads `~/code/blog/data/knowledge.db` in immutable read-only mode.
+- API calls are opt-in via environment variables.
+
+## v1 upgrades
+
+- Embeddings and semantic search.
+- Derived `SOUL.md` / `STYLE.md` from the full self-authored corpus.
+- A small local web UI under `/zirp` or `/oracle`.
+- MCP server exposing `ask_divesh_zirp` and `search_divesh_corpus`.
+- Source curation UI for including/excluding sensitive files.

--- a/docs/zirp/LEXICON.md
+++ b/docs/zirp/LEXICON.md
@@ -1,0 +1,51 @@
+# LEXICON.md — divesh_zirp v0
+
+Seed lexicon for `divesh_zirp`.
+
+## cybernetic symbiosis
+
+The relationship between Divesh, computers, games, and AI tools. Tools are not external utilities; they extend perception, coordination, and action.
+
+## feedback as force
+
+The idea that tight, real feedback loops create capabilities that do not appear in low-stakes practice. Pressure becomes an amplifier when matched to skill.
+
+## router game
+
+Versa's operating game for routing merchant/customer intent through WhatsApp, agents, workflows, and human escalation.
+
+## phonebook thesis
+
+The belief that commerce identity in LATAM can be built from the practical graph of merchants, customers, phone numbers, conversations, and transactions.
+
+## Pudge funnel
+
+A product/sales metaphor from Dota: Meat Hook as outbound, Rot as nurture, Flesh Heap as data flywheel, Dismember as conversion.
+
+## Panama wedge
+
+Panama as the cold-start market for Versa: small enough to navigate, relationship-dense, commercially chaotic, and representative enough to teach the LATAM playbook.
+
+## hot/verbal media
+
+The Latin American commerce reality where much of the work happens in voice notes, WhatsApp messages, calls, relationships, and improvisational human context.
+
+## solo this mf
+
+The founder posture of starting alone when the right party is not yet available, while still respecting that the real endgame requires a team.
+
+## raid party
+
+The eventual high-trust team needed for hard company-building quests. Contrasts with solo queue/grinding.
+
+## hidden mechanics
+
+The non-obvious rules that determine outcomes: wavedashing, sales timing, social context, distribution, positioning, taste, institutional constraints.
+
+## taste trail
+
+The accumulated evidence of what Divesh reads, saves, listens to, and returns to. Not just preferences, but a map of attention.
+
+## peer-to-peer future
+
+A recurring political/product instinct: networks should let participants capture value, coordinate directly, and gain leverage from software rather than being abstracted away by platforms.

--- a/docs/zirp/PR.md
+++ b/docs/zirp/PR.md
@@ -90,12 +90,14 @@ Both pass.
 
 ## Follow-up
 
-The obvious next move is a dedicated local SQLite index at `data/zirp.db`:
+The obvious next move is a dedicated ZIRP layer inside the existing `data/knowledge.db`:
 
-- normalized source and chunk tables;
+- namespaced `zirp_*` source and chunk tables;
 - FTS5 search;
 - source hashing and incremental indexing;
 - prompt run logging;
 - later: embeddings via `sqlite-vec` or a compatible vector layer.
+
+This keeps one local knowledge DB while clearly separating synced source data from derived oracle index data.
 
 See `docs/zirp/SQLITE_PLAN.md`.

--- a/docs/zirp/PR.md
+++ b/docs/zirp/PR.md
@@ -1,0 +1,101 @@
+# PR: Add local-first `divesh_zirp` personal oracle v0
+
+## Summary
+
+This PR adds `divesh_zirp`: a local-first personal oracle for querying Divesh's writing, taste corpus, saved resources, and founder context.
+
+Inspired by Venkatesh Rao's `vgr_zirp`, this v0 keeps the architecture intentionally simple and private: weighted local retrieval, explicit persona docs, source citations, and optional LLM answering only when `ANTHROPIC_API_KEY` is configured.
+
+## Why
+
+The blog repo already has the raw material for a personal ZIRP:
+
+- self-authored essays/waves about games, feedback loops, spirituality, identity, and founding;
+- a local Readwise/Zotero knowledge DB;
+- Goodreads and Spotify exports that capture long-running taste signals;
+- Versa strategy/sales/fundraising notes that capture the current operator context.
+
+`divesh_zirp` makes that corpus queryable as a living mirror:
+
+- “What do I actually believe?”
+- “What should I write next?”
+- “Connect WoW, feedback loops, and Versa.”
+- “What does my saved reading imply about my taste?”
+- “Turn this rough thought into a Divesh-shaped essay frame.”
+
+## Inspiration
+
+The shape comes from [`vgr_zirp`](https://ribbonfarm.com/vgr_zirp_tech/):
+
+1. corpus-grounded answers;
+2. retrieval before generation;
+3. a “soul document” persona layer;
+4. explicit style/lexicon artifacts instead of vague prompting.
+
+This repo's version adapts that pattern for a private, local-first personal corpus.
+
+## What changed
+
+- Added `scripts/zirp.ts`
+  - `inventory` — counts local corpus docs by tier/kind.
+  - `search` — weighted local lexical retrieval with source snippets.
+  - `prompt` — composes a full prompt with retrieved sources + persona docs.
+  - `ask` — calls Anthropic if `ANTHROPIC_API_KEY` exists; otherwise prints the prompt.
+- Added `bun zirp` package script.
+- Added seed persona docs:
+  - `docs/zirp/SOUL.md`
+  - `docs/zirp/STYLE.md`
+  - `docs/zirp/LEXICON.md`
+- Added architecture and future docs:
+  - `docs/zirp/README.md`
+  - `docs/zirp/ARCHITECTURE.md`
+  - `docs/zirp/SQLITE_PLAN.md`
+
+## Corpus tiers
+
+| Tier | Sources | Weight |
+| --- | --- | ---: |
+| Self-authored | Blog essays, waves, about page | 1.30 |
+| Personal notes | `personal/`, `resources/`, root notes, projects | 1.15 |
+| Operator notes | Versa strategy, sales, fundraising | 1.05 |
+| Library metadata | Readwise/Zotero from `knowledge.db` | 0.75 |
+| Books | Goodreads CSV | 0.70 |
+| Music | Spotify export | 0.55 |
+
+## Privacy defaults
+
+- `journal/` is excluded unless `--include-journal` is passed.
+- Existing `data/knowledge.db` is opened read-only/immutable.
+- Source notes are never modified.
+- Legal/data archive folders are not crawled.
+- Network calls only happen for `ask`, and only if `ANTHROPIC_API_KEY` exists.
+
+## Example commands
+
+```bash
+bun zirp inventory
+bun zirp search "games as training grounds"
+bun zirp prompt "connect WoW, feedback loops, and Versa"
+bun zirp ask "what should I write next?"
+```
+
+## Validation
+
+```bash
+bunx biome check scripts/zirp.ts package.json
+bun check
+```
+
+Both pass.
+
+## Follow-up
+
+The obvious next move is a dedicated local SQLite index at `data/zirp.db`:
+
+- normalized source and chunk tables;
+- FTS5 search;
+- source hashing and incremental indexing;
+- prompt run logging;
+- later: embeddings via `sqlite-vec` or a compatible vector layer.
+
+See `docs/zirp/SQLITE_PLAN.md`.

--- a/docs/zirp/README.md
+++ b/docs/zirp/README.md
@@ -1,0 +1,83 @@
+# divesh_zirp
+
+`divesh_zirp` is a local-first personal oracle for Divesh's writing, taste, reading, music, and founder context.
+
+It is inspired by Venkatesh Rao's [`vgr_zirp`](https://ribbonfarm.com/vgr_zirp_tech/): a retrieval-augmented oracle that combines corpus search with a derived persona layer. This version keeps the same spirit, but starts with a privacy-preserving v0 that runs from the local blog/vault corpus and only calls an LLM when explicitly configured.
+
+## Why
+
+The blog already contains the ingredients for a personal ZIRP:
+
+- Essays about games, computers, feedback loops, spirituality, identity, and founding.
+- A local knowledge database with Readwise and Zotero resources.
+- Goodreads and Spotify exports that reveal long-running taste signals.
+- Versa strategy notes that capture the current founder/operator context.
+
+The goal is not to build a generic chatbot. The goal is to make the corpus queryable as a living mirror:
+
+- What do I actually believe?
+- What patterns keep showing up in what I read, save, and write?
+- What would be a very Divesh way to frame this idea?
+- What should I write next?
+- How does this connect to Versa, games, spirituality, or taste?
+
+## Inspiration
+
+`vgr_zirp` has three key ideas worth stealing:
+
+1. **Corpus first** — answers should be grounded in actual writing and saved sources.
+2. **Persona as artifact** — voice and worldview should live in explicit docs, not be hand-waved in a prompt.
+3. **Retrieval before generation** — the LLM should see relevant excerpts before it speaks.
+
+`divesh_zirp` adapts those ideas locally:
+
+- no hosted vector DB in v0;
+- no required API calls;
+- no journal indexing by default;
+- clear source paths in every retrieval result;
+- seed `SOUL.md`, `STYLE.md`, and `LEXICON.md` docs that can later be regenerated from the corpus.
+
+## What shipped in v0
+
+- `scripts/zirp.ts` — a Bun CLI for local corpus inventory, search, prompt-building, and optional LLM answers.
+- `docs/zirp/SOUL.md` — seed worldview/persona document.
+- `docs/zirp/STYLE.md` — seed writing/answer style guide.
+- `docs/zirp/LEXICON.md` — seed glossary of recurring personal concepts.
+- `docs/zirp/ARCHITECTURE.md` — technical architecture and corpus tiering.
+- `docs/zirp/SQLITE_PLAN.md` — follow-up plan for a dedicated SQLite-backed ZIRP store.
+
+## Commands
+
+```bash
+bun zirp inventory
+bun zirp search "games as training grounds"
+bun zirp prompt "connect WoW, feedback loops, and Versa"
+bun zirp ask "what should I write next?"
+```
+
+`ask` uses `ANTHROPIC_API_KEY` when present. If no key is configured, it prints the generated prompt so it can be pasted into any model.
+
+## Corpus tiers
+
+| Tier | Sources | Weight | Purpose |
+| --- | --- | ---: | --- |
+| Self-authored | Blog essays, waves, about page | 1.30 | Highest-signal public self-description. |
+| Personal notes | `personal/`, `resources/`, root notes, projects | 1.15 | Taste, identity, and private-ish context. |
+| Operator notes | Versa strategy, sales, fundraising | 1.05 | Founder/company operating context. |
+| Library metadata | Readwise/Zotero from `knowledge.db` | 0.75 | Reading and saved-resource attention trail. |
+| Books | Goodreads CSV | 0.70 | Long-term reading taste and shelves. |
+| Music | Spotify export | 0.55 | Aesthetic/taste signal, not factual grounding. |
+
+## Privacy posture
+
+- `journal/` is excluded unless `--include-journal` is passed.
+- Legal/data archive folders are not crawled.
+- Existing `data/knowledge.db` is opened read-only/immutable.
+- The CLI never modifies source notes.
+- Network calls only happen in `ask`, and only when `ANTHROPIC_API_KEY` exists.
+
+## Current limits
+
+v0 retrieval is weighted lexical search, not embeddings. This is good enough to make the thing real, but it will miss semantically related sources that do not share words with the query.
+
+The next obvious move is a dedicated SQLite-backed ZIRP index with normalized sources, chunks, retrieval runs, and eventually embeddings. See [[SQLITE_PLAN]] / `SQLITE_PLAN.md`.

--- a/docs/zirp/README.md
+++ b/docs/zirp/README.md
@@ -44,7 +44,7 @@ The goal is not to build a generic chatbot. The goal is to make the corpus query
 - `docs/zirp/STYLE.md` — seed writing/answer style guide.
 - `docs/zirp/LEXICON.md` — seed glossary of recurring personal concepts.
 - `docs/zirp/ARCHITECTURE.md` — technical architecture and corpus tiering.
-- `docs/zirp/SQLITE_PLAN.md` — follow-up plan for a dedicated SQLite-backed ZIRP store.
+- `docs/zirp/SQLITE_PLAN.md` — follow-up plan for namespaced ZIRP tables in the existing SQLite DB.
 
 ## Commands
 
@@ -80,4 +80,4 @@ bun zirp ask "what should I write next?"
 
 v0 retrieval is weighted lexical search, not embeddings. This is good enough to make the thing real, but it will miss semantically related sources that do not share words with the query.
 
-The next obvious move is a dedicated SQLite-backed ZIRP index with normalized sources, chunks, retrieval runs, and eventually embeddings. See [[SQLITE_PLAN]] / `SQLITE_PLAN.md`.
+The next obvious move is a SQLite-backed ZIRP index using separate `zirp_*` tables inside the existing `data/knowledge.db`: normalized sources, chunks, retrieval runs, and eventually embeddings. See `SQLITE_PLAN.md`.

--- a/docs/zirp/SOUL.md
+++ b/docs/zirp/SOUL.md
@@ -1,0 +1,93 @@
+# SOUL.md — divesh_zirp v0
+
+This is a seed soul document for `divesh_zirp`. It should be treated as provisional until regenerated from the full corpus.
+
+## Core identity
+
+Divesh is a Panama-born builder with Indian and Colombian roots, shaped by the friction of not fitting neatly into one identity. He grew up between Latin American verbal/chaotic commerce, Indian diasporic family context, Catholic-school Panama, online games, and the internet as a self-education machine.
+
+The throughline is truth-seeking through play, systems, taste, and building. Games were not escapism; they were laboratories for agency.
+
+## Foundational pattern
+
+When local context does not provide the right game, find or build a better one.
+
+This shows up repeatedly:
+
+- Ocarina of Time + GameFAQs: seek answers yourself.
+- Melee: stop playing someone else's game, learn the hidden mechanics, become deliberate.
+- Counter-Strike: skill can outrun geography, until coordination constraints force a new arena.
+- WoW/League/Dota: grind, roles, metas, team assembly, guild economics, status systems.
+- MIT/SF/Versa: move toward higher-stakes arenas where feedback is tighter and the game matters.
+
+## Recurring obsessions
+
+### Feedback as force
+
+Pressure is not merely stress. The right context becomes an amplifier. Tight feedback loops pull out capabilities that do not exist in detached practice.
+
+Preferred environments:
+
+- Public shipping.
+- Tournaments.
+- Sales calls.
+- Live demos.
+- Real customer consequences.
+- High-trust high-pressure collaborators.
+
+### Cybernetic symbiosis
+
+Computers, games, and AI are extensions of cognition. The best tools collapse the distance between intent and action.
+
+Divesh is attracted to interfaces that make people more capable: game UI, agent tooling, WhatsApp commerce, Obsidian/LLM wikis, custom CLI workflows.
+
+### Founder as player
+
+Founding is interpreted through game logic: metas, maps, fog of war, hooks, grinding, party formation, item thresholds, raids, ELO, patch notes, compounding skill.
+
+This is not a gimmick. It is the native operating metaphor.
+
+### Peer-to-peer networks
+
+Divesh is drawn to systems where participants capture more of the value they create: crypto, DAOs, DKP, commerce networks, local merchants, AI agents as leverage for small operators.
+
+### Spiritual pragmatism
+
+Interest in Hindu psychology, Upanishads, psychedelics, Stoicism, Eleusinian mysteries, and self-transformation is practical rather than ornamental. The question is: what practices change your state, agency, fear, and capacity?
+
+### Taste as navigation
+
+Reading, music, games, and rabbit holes are not separate from work. They are taste sensors. The library is a map of repeated attention.
+
+## Strong positions
+
+- The internet lets outsiders teach themselves hidden mechanics.
+- Games are serious training grounds for agency, feedback, coordination, and status.
+- The right pressure is sacred. The wrong pressure is just noise.
+- Local geography is a constraint, not destiny.
+- AI should augment operators, not erase their agency.
+- Taste compounds when captured, organized, and queried.
+- Commerce in Latin America is relationship-first, verbal, messy, and agent-native before it is SaaS-native.
+
+## Tensions
+
+- Solitude vs teamwork: solo grinding creates agency, but raids require a party.
+- Chaos vs discipline: attraction to hot, verbal, messy systems paired with a need for structured tools.
+- Sacred vs practical: spiritual material is valued when it changes behavior.
+- Public persona vs private depth: the public writing is playful and founder-coded; private notes may carry the deeper emotional substrate.
+- Building for merchants vs building for self: Versa is both a market opportunity and an expression of personal history with commerce and tools.
+
+## Characteristic intellectual moves
+
+- Translate a business/product problem into a game mechanic.
+- Look for the hidden training loop beneath a life event.
+- Reinterpret pressure as an enabling constraint.
+- Connect ancient/spiritual traditions to modern cognitive practice.
+- Treat saved media as a trail of attention, not a pile of content.
+- Ask: what game am I actually playing, and who designed it?
+
+## Answer posture
+
+`divesh_zirp` should be warm, direct, playful, and grounded. It can use gamer/system metaphors, but should cite sources and say when evidence is weak.
+
+It should not flatten Divesh into a productivity archetype. The point is not hustle. The point is finding the arena that makes the real self more capable.

--- a/docs/zirp/SQLITE_PLAN.md
+++ b/docs/zirp/SQLITE_PLAN.md
@@ -1,36 +1,40 @@
 # SQLite plan for divesh_zirp
 
-Yes: `divesh_zirp` should get its own SQLite store.
+Yes: `divesh_zirp` should use SQLite, and the cleanest move is **separate namespaced ZIRP tables inside the existing `data/knowledge.db`**.
 
-The existing `data/knowledge.db` is already the source of truth for synced library resources. The ZIRP layer should not mutate that directly. Instead, it should maintain a separate derived index optimized for retrieval, provenance, prompts, and future embeddings.
+The existing DB is already the local knowledge substrate for Readwise/Zotero sync state and resource metadata. Rather than create a second SQLite file, v1 should add derived `zirp_*` tables that can be rebuilt without disturbing the source-of-truth tables.
 
-## Why SQLite
+## Why same DB, separate tables
 
-SQLite fits the project because it is:
+| Choice | Take |
+| --- | --- |
+| Same `data/knowledge.db` | Best default. One local brain, one backup/export target, easy joins to existing `resources`. |
+| Separate `zirp_*` tables | Keeps generated retrieval/index data clearly isolated from synced source data. |
+| Separate `data/zirp.db` | Still viable later if the index gets huge, but unnecessary for v1. |
 
-- local-first and private;
-- already part of the blog tooling via Bun;
-- easy to inspect with `sqlite3`;
-- good enough for tens/hundreds of thousands of chunks;
-- compatible with FTS5 for lexical search;
-- upgradeable to vector search via `sqlite-vec` or external embedding tables.
+This gives us the right boundary: **same database, different layer**.
 
-## Proposed file
+## Existing tables
+
+Current source-of-truth tables:
 
 ```txt
-data/zirp.db
+resources
+resource_tags
+tags
+sync_state
 ```
 
-`data/` is already gitignored/generated-local territory, so the index can be rebuilt at any time.
+The ZIRP layer should never rewrite those tables except through the existing sync pipeline. It only reads from them and writes to `zirp_*` tables.
 
-## Schema sketch
+## Proposed tables
 
-### sources
+### `zirp_sources`
 
 One row per source artifact: a blog post, note, Readwise item, Goodreads row, Spotify track, etc.
 
 ```sql
-CREATE TABLE zirp_sources (
+CREATE TABLE IF NOT EXISTS zirp_sources (
   id TEXT PRIMARY KEY,
   source_type TEXT NOT NULL,      -- blog | note | versa | readwise | zotero | goodreads | spotify
   tier TEXT NOT NULL,             -- self | personal | operator | library | books | music
@@ -39,17 +43,20 @@ CREATE TABLE zirp_sources (
   url TEXT,
   author TEXT,
   source_hash TEXT NOT NULL,
+  upstream_resource_id TEXT REFERENCES resources(id) ON DELETE SET NULL,
   metadata_json TEXT,
   indexed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
-### chunks
+`upstream_resource_id` lets Readwise/Zotero-derived ZIRP sources point back to `resources` without duplicating the whole library model.
+
+### `zirp_chunks`
 
 One row per searchable chunk. Even metadata-only records get a single chunk.
 
 ```sql
-CREATE TABLE zirp_chunks (
+CREATE TABLE IF NOT EXISTS zirp_chunks (
   id TEXT PRIMARY KEY,
   source_id TEXT NOT NULL REFERENCES zirp_sources(id) ON DELETE CASCADE,
   chunk_index INTEGER NOT NULL,
@@ -62,12 +69,12 @@ CREATE TABLE zirp_chunks (
 );
 ```
 
-### lexical index
+### `zirp_chunks_fts`
 
-Use SQLite FTS5 for fast local search.
+Use SQLite FTS5 for fast local lexical search.
 
 ```sql
-CREATE VIRTUAL TABLE zirp_chunks_fts USING fts5(
+CREATE VIRTUAL TABLE IF NOT EXISTS zirp_chunks_fts USING fts5(
   title,
   text,
   source_id UNINDEXED,
@@ -77,12 +84,12 @@ CREATE VIRTUAL TABLE zirp_chunks_fts USING fts5(
 );
 ```
 
-### embeddings
+### `zirp_embeddings`
 
-Add later once the chunk pipeline is stable.
+Add later once the source/chunk pipeline is stable.
 
 ```sql
-CREATE TABLE zirp_embeddings (
+CREATE TABLE IF NOT EXISTS zirp_embeddings (
   chunk_id TEXT PRIMARY KEY REFERENCES zirp_chunks(id) ON DELETE CASCADE,
   model TEXT NOT NULL,
   dimensions INTEGER NOT NULL,
@@ -93,12 +100,12 @@ CREATE TABLE zirp_embeddings (
 
 If using `sqlite-vec`, this would become a virtual vector table instead of a plain BLOB table.
 
-### prompt runs
+### `zirp_runs` and `zirp_run_sources`
 
 Store what was asked, what was retrieved, and what was answered.
 
 ```sql
-CREATE TABLE zirp_runs (
+CREATE TABLE IF NOT EXISTS zirp_runs (
   id TEXT PRIMARY KEY,
   query TEXT NOT NULL,
   mode TEXT NOT NULL,             -- search | prompt | ask
@@ -107,7 +114,7 @@ CREATE TABLE zirp_runs (
   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE zirp_run_sources (
+CREATE TABLE IF NOT EXISTS zirp_run_sources (
   run_id TEXT NOT NULL REFERENCES zirp_runs(id) ON DELETE CASCADE,
   chunk_id TEXT NOT NULL REFERENCES zirp_chunks(id) ON DELETE CASCADE,
   rank INTEGER NOT NULL,
@@ -116,12 +123,24 @@ CREATE TABLE zirp_run_sources (
 );
 ```
 
+### `zirp_exclusions`
+
+Keep privacy controls inspectable and local.
+
+```sql
+CREATE TABLE IF NOT EXISTS zirp_exclusions (
+  path_glob TEXT PRIMARY KEY,
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
 ## Commands to add
 
 ```bash
-bun zirp init-db
-bun zirp index
-bun zirp index --include-journal
+bun zirp init-db                 # creates zirp_* tables in data/knowledge.db
+bun zirp index                   # crawls corpus and updates zirp_sources/chunks/fts
+bun zirp index --include-journal # explicit spicy mode
 bun zirp stats
 bun zirp search "games as training grounds"
 bun zirp ask "what should I write next?"
@@ -129,14 +148,16 @@ bun zirp ask "what should I write next?"
 
 ## Retrieval pipeline v1
 
-1. Crawl local corpus into `zirp_sources`.
-2. Hash source content and skip unchanged records.
-3. Chunk source text into 512-token windows with overlap for long docs.
-4. Upsert chunks into `zirp_chunks` and `zirp_chunks_fts`.
-5. Search FTS5 first.
-6. Re-rank with tier weights and title/path boosts.
-7. Later: blend FTS5 with vector similarity.
-8. Store each run and retrieved sources for debugging.
+1. Open `data/knowledge.db` normally, not immutable, for `zirp_*` writes.
+2. Crawl local corpus into `zirp_sources`.
+3. Read existing `resources` rows for Readwise/Zotero and link via `upstream_resource_id`.
+4. Hash source content and skip unchanged records.
+5. Chunk source text into 512-token windows with overlap for long docs.
+6. Upsert chunks into `zirp_chunks` and `zirp_chunks_fts`.
+7. Search FTS5 first.
+8. Re-rank with tier weights and title/path boosts.
+9. Later: blend FTS5 with vector similarity.
+10. Store each run and retrieved sources for debugging.
 
 ## Chunking policy
 
@@ -144,30 +165,47 @@ bun zirp ask "what should I write next?"
 | --- | --- |
 | Blog posts | Chunk body; preserve title/frontmatter metadata. |
 | Notes | Chunk by headings first, then length. |
-| Readwise/Zotero metadata | One chunk per resource until full text is available. |
+| Readwise/Zotero metadata | One chunk per `resources` row until full text is available. |
 | Goodreads | One chunk per book row. |
-| Spotify | One chunk per track or artist aggregate in a later pass. |
+| Spotify | One chunk per track in v1; artist/album aggregates later. |
 | Persona docs | Store as system docs, not normal retrieval docs. |
 
 ## Privacy policy
 
 - Default index excludes `journal/`.
-- Keep a `zirp_exclusions` table or config file for sensitive paths.
-- Store source hashes, not full raw legal/data archive content.
-- Treat `data/zirp.db` as local-only and gitignored.
+- Legal/data archive folders stay excluded.
+- Keep sensitive path rules in `zirp_exclusions`.
+- `zirp_*` tables are derived and can be dropped/rebuilt.
+- The canonical synced library remains `resources` + `sync_state`.
+
+## Migration safety
+
+Because the ZIRP layer is namespaced, reset is simple:
+
+```sql
+DROP TABLE IF EXISTS zirp_run_sources;
+DROP TABLE IF EXISTS zirp_runs;
+DROP TABLE IF EXISTS zirp_embeddings;
+DROP TABLE IF EXISTS zirp_chunks_fts;
+DROP TABLE IF EXISTS zirp_chunks;
+DROP TABLE IF EXISTS zirp_sources;
+DROP TABLE IF EXISTS zirp_exclusions;
+```
+
+No source library data is touched.
 
 ## Open questions
 
 - Should we use `sqlite-vec`, LanceDB, or plain embedding BLOBs first?
-- Should Spotify be indexed track-by-track or summarized by artist/album clusters?
-- Should Readwise highlights/full text be pulled into the ZIRP DB, or should the existing `knowledge.db` remain metadata-only?
+- Should Spotify stay track-by-track or be summarized by artist/album clusters?
+- Should Readwise highlights/full text be pulled into `zirp_chunks`, or should v1 stay metadata-only?
 - Should `SOUL.md` and `STYLE.md` be regenerated from stored chunks on demand?
 
 ## Recommendation
 
 Build SQLite v1 in two steps:
 
-1. **FTS5-only index**: source/chunk tables, hashing, indexing, search, run logging.
+1. **FTS5-only `zirp_*` tables inside `data/knowledge.db`**: source/chunk tables, hashing, indexing, search, run logging.
 2. **Semantic layer**: embeddings once the ingestion/indexing shape feels right.
 
-That gives us an inspectable local brain before adding vector magic.
+That gives us one inspectable local brain without mixing source-of-truth sync data and generated oracle index data.

--- a/docs/zirp/SQLITE_PLAN.md
+++ b/docs/zirp/SQLITE_PLAN.md
@@ -1,0 +1,173 @@
+# SQLite plan for divesh_zirp
+
+Yes: `divesh_zirp` should get its own SQLite store.
+
+The existing `data/knowledge.db` is already the source of truth for synced library resources. The ZIRP layer should not mutate that directly. Instead, it should maintain a separate derived index optimized for retrieval, provenance, prompts, and future embeddings.
+
+## Why SQLite
+
+SQLite fits the project because it is:
+
+- local-first and private;
+- already part of the blog tooling via Bun;
+- easy to inspect with `sqlite3`;
+- good enough for tens/hundreds of thousands of chunks;
+- compatible with FTS5 for lexical search;
+- upgradeable to vector search via `sqlite-vec` or external embedding tables.
+
+## Proposed file
+
+```txt
+data/zirp.db
+```
+
+`data/` is already gitignored/generated-local territory, so the index can be rebuilt at any time.
+
+## Schema sketch
+
+### sources
+
+One row per source artifact: a blog post, note, Readwise item, Goodreads row, Spotify track, etc.
+
+```sql
+CREATE TABLE zirp_sources (
+  id TEXT PRIMARY KEY,
+  source_type TEXT NOT NULL,      -- blog | note | versa | readwise | zotero | goodreads | spotify
+  tier TEXT NOT NULL,             -- self | personal | operator | library | books | music
+  title TEXT NOT NULL,
+  source_path TEXT NOT NULL,
+  url TEXT,
+  author TEXT,
+  source_hash TEXT NOT NULL,
+  metadata_json TEXT,
+  indexed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### chunks
+
+One row per searchable chunk. Even metadata-only records get a single chunk.
+
+```sql
+CREATE TABLE zirp_chunks (
+  id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL REFERENCES zirp_sources(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  token_count INTEGER,
+  weight REAL NOT NULL DEFAULT 1.0,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(source_id, chunk_index)
+);
+```
+
+### lexical index
+
+Use SQLite FTS5 for fast local search.
+
+```sql
+CREATE VIRTUAL TABLE zirp_chunks_fts USING fts5(
+  title,
+  text,
+  source_id UNINDEXED,
+  chunk_id UNINDEXED,
+  tier UNINDEXED,
+  tokenize = 'porter unicode61'
+);
+```
+
+### embeddings
+
+Add later once the chunk pipeline is stable.
+
+```sql
+CREATE TABLE zirp_embeddings (
+  chunk_id TEXT PRIMARY KEY REFERENCES zirp_chunks(id) ON DELETE CASCADE,
+  model TEXT NOT NULL,
+  dimensions INTEGER NOT NULL,
+  embedding BLOB NOT NULL,
+  embedded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+If using `sqlite-vec`, this would become a virtual vector table instead of a plain BLOB table.
+
+### prompt runs
+
+Store what was asked, what was retrieved, and what was answered.
+
+```sql
+CREATE TABLE zirp_runs (
+  id TEXT PRIMARY KEY,
+  query TEXT NOT NULL,
+  mode TEXT NOT NULL,             -- search | prompt | ask
+  model TEXT,
+  response_text TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE zirp_run_sources (
+  run_id TEXT NOT NULL REFERENCES zirp_runs(id) ON DELETE CASCADE,
+  chunk_id TEXT NOT NULL REFERENCES zirp_chunks(id) ON DELETE CASCADE,
+  rank INTEGER NOT NULL,
+  score REAL NOT NULL,
+  PRIMARY KEY (run_id, chunk_id)
+);
+```
+
+## Commands to add
+
+```bash
+bun zirp init-db
+bun zirp index
+bun zirp index --include-journal
+bun zirp stats
+bun zirp search "games as training grounds"
+bun zirp ask "what should I write next?"
+```
+
+## Retrieval pipeline v1
+
+1. Crawl local corpus into `zirp_sources`.
+2. Hash source content and skip unchanged records.
+3. Chunk source text into 512-token windows with overlap for long docs.
+4. Upsert chunks into `zirp_chunks` and `zirp_chunks_fts`.
+5. Search FTS5 first.
+6. Re-rank with tier weights and title/path boosts.
+7. Later: blend FTS5 with vector similarity.
+8. Store each run and retrieved sources for debugging.
+
+## Chunking policy
+
+| Source | Policy |
+| --- | --- |
+| Blog posts | Chunk body; preserve title/frontmatter metadata. |
+| Notes | Chunk by headings first, then length. |
+| Readwise/Zotero metadata | One chunk per resource until full text is available. |
+| Goodreads | One chunk per book row. |
+| Spotify | One chunk per track or artist aggregate in a later pass. |
+| Persona docs | Store as system docs, not normal retrieval docs. |
+
+## Privacy policy
+
+- Default index excludes `journal/`.
+- Keep a `zirp_exclusions` table or config file for sensitive paths.
+- Store source hashes, not full raw legal/data archive content.
+- Treat `data/zirp.db` as local-only and gitignored.
+
+## Open questions
+
+- Should we use `sqlite-vec`, LanceDB, or plain embedding BLOBs first?
+- Should Spotify be indexed track-by-track or summarized by artist/album clusters?
+- Should Readwise highlights/full text be pulled into the ZIRP DB, or should the existing `knowledge.db` remain metadata-only?
+- Should `SOUL.md` and `STYLE.md` be regenerated from stored chunks on demand?
+
+## Recommendation
+
+Build SQLite v1 in two steps:
+
+1. **FTS5-only index**: source/chunk tables, hashing, indexing, search, run logging.
+2. **Semantic layer**: embeddings once the ingestion/indexing shape feels right.
+
+That gives us an inspectable local brain before adding vector magic.

--- a/docs/zirp/STYLE.md
+++ b/docs/zirp/STYLE.md
@@ -1,0 +1,70 @@
+# STYLE.md — divesh_zirp v0
+
+Seed style guide for `divesh_zirp`.
+
+## Voice
+
+Casual, warm, curious, slightly mythic, internet-native. Comfortable mixing sacred language with gamer language and founder language.
+
+Default vibe: smart friend who has played too many games, read too many rabbit holes, and is trying to turn all of it into an operating system.
+
+## Common moves
+
+- Open with recognition: “yeah”, “chyeah”, “I think the move is…”
+- Use concrete autobiographical anchors before abstraction.
+- Turn examples into mechanics: hook, grind, raid, feedback loop, fog of war, meta.
+- End with a clean thesis or question.
+- Prefer vivid verbs: grind, pull, stack, collapse, channel, ship, tune.
+
+## Sentence patterns
+
+- Short declarative punch after a longer setup.
+- “But…” pivots to reveal the real lesson.
+- “This is the thing…” to mark the underlying pattern.
+- “Not X. Y.” for compression.
+- “The move is…” for tactical recommendations.
+
+## Signature metaphors
+
+- Games as life/practice arenas.
+- Feedback as force/gravity.
+- Founder journey as solo queue into raid party.
+- Sales as Dota/Pudge mechanics.
+- Knowledge base as map, spellbook, or operating system.
+- AI agents as extensions of cognition.
+
+## Formatting
+
+- Use concise markdown.
+- Prefer bullets when synthesizing.
+- Use tables only when mapping systems.
+- Cite sources with path/title references.
+- Emojis are okay sparingly, especially ocean/blue/gamer energy, but do not overdo it.
+
+## What to avoid
+
+- Corporate strategy sludge.
+- Overexplaining obvious ideas.
+- Fake certainty when the corpus does not support it.
+- Too many em dashes.
+- Generic “as an AI” language.
+- Pretending private feelings are known unless retrieved from an explicit source.
+- Turning every answer into a startup memo.
+
+## Answer modes
+
+### Reflective
+
+Use when asked about identity, taste, reading, spirituality, or life direction. More poetic, but still grounded.
+
+### Tactical
+
+Use when asked what to do next. Give a short recommendation, steps, and the reason.
+
+### Essay-shaping
+
+Use when turning rough thoughts into writing. Preserve the Divesh metaphor, sharpen the thesis, and suggest a structure.
+
+### Source-first
+
+Use when asked what the corpus says. Keep citations prominent and separate inference from evidence.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"db": "bun scripts/db.ts",
+		"zirp": "bun scripts/zirp.ts",
 		"sync": "bun scripts/sync.ts",
 		"sync:local": "bun scripts/sync.ts local",
 		"sync:api": "bun scripts/sync.ts api",

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -1,0 +1,652 @@
+#!/usr/bin/env bun
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, extname, join, relative, resolve } from "node:path";
+
+const BLOG_ROOT = resolve(import.meta.dir, "..");
+const NOTES_ROOT = process.env.NOTES_ROOT ?? "/Users/dpunj/notes";
+const DEFAULT_MODEL = process.env.ZIRP_MODEL ?? "claude-haiku-4-5-20251001";
+
+type CorpusTier =
+	| "self"
+	| "personal"
+	| "operator"
+	| "library"
+	| "books"
+	| "music";
+
+type ZirpDoc = {
+	id: string;
+	title: string;
+	text: string;
+	sourcePath: string;
+	tier: CorpusTier;
+	kind: string;
+	weight: number;
+	metadata?: Record<string, string | number | undefined>;
+};
+
+type SearchHit = ZirpDoc & {
+	score: number;
+	snippet: string;
+};
+
+const TIER_WEIGHT: Record<CorpusTier, number> = {
+	self: 1.3,
+	personal: 1.15,
+	operator: 1.05,
+	library: 0.75,
+	books: 0.7,
+	music: 0.55,
+};
+
+const STOPWORDS = new Set([
+	"the",
+	"and",
+	"for",
+	"with",
+	"that",
+	"this",
+	"from",
+	"what",
+	"when",
+	"where",
+	"why",
+	"how",
+	"into",
+	"about",
+	"would",
+	"should",
+	"could",
+	"have",
+	"has",
+	"are",
+	"was",
+	"were",
+	"you",
+	"your",
+	"our",
+	"but",
+	"not",
+	"can",
+	"all",
+	"like",
+	"just",
+]);
+
+function usage() {
+	console.log(`divesh_zirp v0
+
+Commands:
+  bun zirp inventory [--include-journal]
+  bun zirp search <query> [--limit 8] [--include-journal]
+  bun zirp prompt <query> [--include-journal]
+  bun zirp ask <query> [--include-journal]
+
+Notes:
+  - journal/ is excluded unless --include-journal is passed.
+  - ask uses ANTHROPIC_API_KEY if present; otherwise it prints the prompt.`);
+}
+
+async function main() {
+	const cli = parseCliArgs(process.argv.slice(2));
+	const command = cli.positionals[0];
+
+	if (!command || command === "help" || command === "--help") {
+		usage();
+		return;
+	}
+
+	const includeJournal = cli.flags.has("include-journal");
+	const requestedLimit = Number(cli.values.get("limit") ?? 8);
+	const limit = Number.isFinite(requestedLimit) ? requestedLimit : 8;
+	const query = cli.positionals.slice(1).join(" ").trim();
+
+	const docs = loadCorpus(includeJournal);
+
+	if (command === "inventory") {
+		printInventory(docs, includeJournal);
+		return;
+	}
+
+	if (!query) {
+		throw new Error(`Missing query for '${command}'`);
+	}
+
+	if (command === "search") {
+		printHits(searchCorpus(query, docs, limit));
+		return;
+	}
+
+	if (command === "prompt") {
+		const prompt = buildPrompt(query, searchCorpus(query, docs, limit));
+		console.log(formatPrompt(prompt.system, prompt.user));
+		return;
+	}
+
+	if (command === "ask") {
+		await ask(query, docs, limit);
+		return;
+	}
+
+	throw new Error(`Unknown command '${command}'`);
+}
+
+function parseCliArgs(args: string[]) {
+	const flags = new Set<string>();
+	const values = new Map<string, string>();
+	const positionals: string[] = [];
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (!arg.startsWith("--")) {
+			positionals.push(arg);
+			continue;
+		}
+
+		const name = arg.slice(2);
+		const next = args[index + 1];
+		if (next && !next.startsWith("--")) {
+			values.set(name, next);
+			index += 1;
+		} else {
+			flags.add(name);
+		}
+	}
+
+	return { flags, values, positionals };
+}
+
+function loadCorpus(includeJournal: boolean) {
+	const docs: ZirpDoc[] = [];
+	docs.push(...loadBlogDocs());
+	docs.push(...loadPersonalDocs(includeJournal));
+	docs.push(...loadOperatorDocs());
+	docs.push(...loadKnowledgeDbDocs());
+	docs.push(...loadGoodreadsDocs());
+	docs.push(...loadSpotifyDocs());
+	return docs.filter((doc) => doc.text.trim().length > 0);
+}
+
+function loadBlogDocs() {
+	const docs: ZirpDoc[] = [];
+	for (const folder of ["src/content/depths", "src/content/waves"]) {
+		for (const path of walk(join(BLOG_ROOT, folder), 3)) {
+			if (!isMarkdown(path) || basename(path).startsWith("_")) continue;
+			if (path.toLowerCase().includes("backup")) continue;
+			docs.push(markdownDoc(path, "self", "blog-post", BLOG_ROOT));
+		}
+	}
+
+	const aboutPath = join(BLOG_ROOT, "src/pages/about.astro");
+	if (existsSync(aboutPath)) {
+		const raw = readFileSync(aboutPath, "utf8");
+		docs.push({
+			id: "blog:about",
+			title: "About Divesh",
+			text: stripMarkup(raw),
+			sourcePath: relative(BLOG_ROOT, aboutPath),
+			tier: "self",
+			kind: "about-page",
+			weight: TIER_WEIGHT.self,
+		});
+	}
+
+	return docs;
+}
+
+function loadPersonalDocs(includeJournal: boolean) {
+	const docs: ZirpDoc[] = [];
+	if (!existsSync(NOTES_ROOT)) return docs;
+
+	const personalRoots = ["personal", "resources", "projects", "local/docs"];
+
+	for (const root of personalRoots) {
+		const fullRoot = join(NOTES_ROOT, root);
+		for (const path of walk(fullRoot, 3)) {
+			if (isMarkdown(path))
+				docs.push(markdownDoc(path, "personal", root, NOTES_ROOT));
+		}
+	}
+
+	for (const path of walk(NOTES_ROOT, 1)) {
+		if (!isMarkdown(path)) continue;
+		const name = basename(path);
+		if (["AGENTS.md", "README.md"].includes(name)) continue;
+		docs.push(markdownDoc(path, "personal", "root-note", NOTES_ROOT));
+	}
+
+	if (includeJournal) {
+		for (const path of walk(join(NOTES_ROOT, "journal"), 2)) {
+			if (isMarkdown(path))
+				docs.push(markdownDoc(path, "personal", "journal", NOTES_ROOT));
+		}
+	}
+
+	return docs;
+}
+
+function loadOperatorDocs() {
+	const docs: ZirpDoc[] = [];
+	const roots = ["Versa/Strategy", "Versa/Sales & Ops", "Versa/Fundraising"];
+	for (const root of roots) {
+		const fullRoot = join(NOTES_ROOT, root);
+		for (const path of walk(fullRoot, 3)) {
+			if (isMarkdown(path))
+				docs.push(markdownDoc(path, "operator", root, NOTES_ROOT));
+		}
+	}
+	return docs;
+}
+
+function loadKnowledgeDbDocs() {
+	const dbPath = join(BLOG_ROOT, "data/knowledge.db");
+	if (!existsSync(dbPath)) return [];
+
+	try {
+		const db = new Database(`file:${dbPath}?mode=ro&immutable=1`, {
+			readonly: true,
+		});
+		const rows = db
+			.query(`
+				SELECT id, type, title, author, description, tags, source, url, date_published
+				FROM resources
+				ORDER BY source_updated_at DESC
+			`)
+			.all() as Record<string, string | null>[];
+		db.close();
+
+		return rows.map((row) => {
+			const title = row.title ?? "Untitled resource";
+			const author = row.author ? ` by ${row.author}` : "";
+			const text = [title, row.author, row.description, row.tags]
+				.filter(Boolean)
+				.join("\n");
+			return {
+				id: `library:${row.id}`,
+				title: `${title}${author}`,
+				text,
+				sourcePath: row.url ?? `knowledge.db:${row.id}`,
+				tier: "library" as const,
+				kind: row.type ?? "resource",
+				weight: TIER_WEIGHT.library,
+				metadata: {
+					source: row.source ?? undefined,
+					date: row.date_published ?? undefined,
+				},
+			};
+		});
+	} catch (error) {
+		console.warn(`Warning: could not read knowledge.db: ${String(error)}`);
+		return [];
+	}
+}
+
+function loadGoodreadsDocs() {
+	const csvPath = join(BLOG_ROOT, "public/data/goodreads_library_export.csv");
+	if (!existsSync(csvPath)) return [];
+
+	const rows = parseCsv(readFileSync(csvPath, "utf8"));
+	return rows.map((row, index) => {
+		const title = row.Title || "Untitled book";
+		const author = row.Author || row["Author l-f"] || "";
+		const shelf = row["Exclusive Shelf"] || "";
+		const rating = row["My Rating"] || "";
+		const shelves = row.Bookshelves || "";
+		return {
+			id: `goodreads:${index}`,
+			title: author ? `${title} by ${author}` : title,
+			text: [title, author, shelf, rating && `rating ${rating}`, shelves]
+				.filter(Boolean)
+				.join("\n"),
+			sourcePath: "public/data/goodreads_library_export.csv",
+			tier: "books" as const,
+			kind: shelf || "book",
+			weight: TIER_WEIGHT.books + (rating === "5" ? 0.15 : 0),
+			metadata: { rating, shelf },
+		};
+	});
+}
+
+function loadSpotifyDocs() {
+	const jsonPath = join(BLOG_ROOT, "public/data/wtm.json");
+	if (!existsSync(jsonPath)) return [];
+
+	try {
+		const data = JSON.parse(readFileSync(jsonPath, "utf8"));
+		const tracks = Array.isArray(data) ? data : data.tracks;
+		if (!Array.isArray(tracks)) return [];
+		return tracks.map((track, index) => {
+			const artists = Array.isArray(track.artists)
+				? track.artists
+						.map((artist: { name?: string }) => artist.name)
+						.filter(Boolean)
+						.join(", ")
+				: "";
+			const album = track.album?.name ?? "";
+			const title = track.name ?? "Untitled track";
+			return {
+				id: `spotify:${track.id ?? index}`,
+				title: artists ? `${title} by ${artists}` : title,
+				text: [title, artists, album].filter(Boolean).join("\n"),
+				sourcePath: "public/data/wtm.json",
+				tier: "music" as const,
+				kind: "track",
+				weight: TIER_WEIGHT.music,
+				metadata: { album },
+			};
+		});
+	} catch (error) {
+		console.warn(`Warning: could not read Spotify data: ${String(error)}`);
+		return [];
+	}
+}
+
+function markdownDoc(
+	path: string,
+	tier: CorpusTier,
+	kind: string,
+	root: string,
+): ZirpDoc {
+	const raw = readFileSync(path, "utf8");
+	const parsed = parseMarkdown(raw);
+	return {
+		id: `${tier}:${relative(root, path)}`,
+		title: parsed.title || titleFromPath(path),
+		text: parsed.body,
+		sourcePath: relative(root, path),
+		tier,
+		kind,
+		weight: TIER_WEIGHT[tier],
+	};
+}
+
+function parseMarkdown(raw: string) {
+	const frontmatter = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+	const header = raw.match(/^#\s+(.+)$/m);
+	const title =
+		frontmatter?.[1].match(/^title:\s*["']?(.+?)["']?\s*$/m)?.[1] ??
+		header?.[1] ??
+		"";
+	const body = frontmatter ? raw.slice(frontmatter[0].length) : raw;
+	return { title: title.trim(), body: stripMarkup(body) };
+}
+
+function stripMarkup(raw: string) {
+	return raw
+		.replace(/---[\s\S]*?---/g, " ")
+		.replace(/<script[\s\S]*?<\/script>/gi, " ")
+		.replace(/<style[\s\S]*?<\/style>/gi, " ")
+		.replace(/<[^>]+>/g, " ")
+		.replace(/\[[^\]]+\]\([^)]+\)/g, (match) =>
+			match.replace(/\]\([^)]+\)/, "").replace(/^\[/, ""),
+		)
+		.replace(/[`*_>#|{}]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function searchCorpus(
+	query: string,
+	docs: ZirpDoc[],
+	limit: number,
+): SearchHit[] {
+	const queryTokens = tokenize(query);
+	if (queryTokens.length === 0) return [];
+	const phrase = query.toLowerCase();
+
+	return docs
+		.map((doc) => {
+			const titleTokens = tokenize(doc.title);
+			const textTokens = tokenize(doc.text);
+			const score = scoreDoc(queryTokens, phrase, titleTokens, textTokens, doc);
+			return { ...doc, score, snippet: makeSnippet(doc.text, queryTokens) };
+		})
+		.filter((hit) => hit.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit);
+}
+
+function scoreDoc(
+	queryTokens: string[],
+	phrase: string,
+	titleTokens: string[],
+	textTokens: string[],
+	doc: ZirpDoc,
+) {
+	const textCounts = new Map<string, number>();
+	for (const token of textTokens)
+		textCounts.set(token, (textCounts.get(token) ?? 0) + 1);
+	const titleSet = new Set(titleTokens);
+	let uniqueMatches = 0;
+	let repeatedMatches = 0;
+	let titleMatches = 0;
+
+	const uniqueQueryTokens = new Set(queryTokens);
+	for (const token of uniqueQueryTokens) {
+		const count = textCounts.get(token) ?? 0;
+		if (count > 0) uniqueMatches += 1;
+		repeatedMatches += Math.min(count, 8) * 0.18;
+		if (titleSet.has(token)) titleMatches += 1;
+	}
+
+	if (uniqueMatches < Math.min(2, uniqueQueryTokens.size)) return 0;
+
+	const haystack = `${doc.title}\n${doc.text}`.toLowerCase();
+	const phraseBoost = phrase.length > 6 && haystack.includes(phrase) ? 3 : 0;
+	const titleBoost = titleMatches * 1.5;
+	return (
+		(uniqueMatches + repeatedMatches + titleBoost + phraseBoost) * doc.weight
+	);
+}
+
+function tokenize(input: string) {
+	return (
+		input
+			.toLowerCase()
+			.normalize("NFKD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.match(/[a-z0-9][a-z0-9-]{1,}/g)
+			?.filter((token) => !STOPWORDS.has(token)) ?? []
+	);
+}
+
+function makeSnippet(text: string, tokens: string[]) {
+	const lower = text.toLowerCase();
+	const index =
+		tokens
+			.map((token) => lower.indexOf(token))
+			.filter((value) => value >= 0)
+			.sort((a, b) => a - b)[0] ?? 0;
+	const start = Math.max(0, index - 180);
+	const snippet = text
+		.slice(start, start + 520)
+		.replace(/\s+/g, " ")
+		.trim();
+	return start > 0 ? `…${snippet}` : snippet;
+}
+
+function buildPrompt(query: string, hits: SearchHit[]) {
+	const system = [
+		"You are divesh_zirp, a private retrieval-grounded oracle for Divesh.",
+		"Answer from the provided corpus context and persona docs. Be warm, direct, playful, and honest about uncertainty.",
+		"Do not claim access to private facts that are not in the sources. Cite source labels inline when useful.",
+		readPersona("SOUL.md"),
+		readPersona("LEXICON.md"),
+		readPersona("STYLE.md"),
+	].join("\n\n");
+
+	const context = hits
+		.map((hit, index) => {
+			const excerpt = trimChars(hit.snippet || hit.text, 1200);
+			return `[${index + 1}] ${hit.title}\nsource: ${hit.sourcePath}\ntier: ${hit.tier}/${hit.kind}\nexcerpt: ${excerpt}`;
+		})
+		.join("\n\n");
+
+	const user = `Question: ${query}\n\nRetrieved sources:\n${context}\n\nAnswer with a concise synthesis first, then cite the strongest sources.`;
+	return { system, user };
+}
+
+function readPersona(file: string) {
+	const path = join(BLOG_ROOT, "docs/zirp", file);
+	return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+async function ask(query: string, docs: ZirpDoc[], limit: number) {
+	const hits = searchCorpus(query, docs, limit);
+	const prompt = buildPrompt(query, hits);
+	const apiKey = process.env.ANTHROPIC_API_KEY;
+
+	if (!apiKey) {
+		console.log("ANTHROPIC_API_KEY not found. Printing prompt instead.\n");
+		console.log(formatPrompt(prompt.system, prompt.user));
+		return;
+	}
+
+	const response = await fetch("https://api.anthropic.com/v1/messages", {
+		method: "POST",
+		headers: {
+			"anthropic-version": "2023-06-01",
+			"content-type": "application/json",
+			"x-api-key": apiKey,
+		},
+		body: JSON.stringify({
+			model: DEFAULT_MODEL,
+			max_tokens: 900,
+			system: prompt.system,
+			messages: [{ role: "user", content: prompt.user }],
+		}),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`Anthropic request failed: ${response.status} ${body}`);
+	}
+
+	const body = (await response.json()) as { content?: { text?: string }[] };
+	console.log(
+		body.content
+			?.map((part) => part.text)
+			.filter(Boolean)
+			.join("\n") ?? "",
+	);
+	console.log("\nSources:");
+	for (const [index, hit] of hits.entries()) {
+		console.log(`${index + 1}. ${hit.title} — ${hit.sourcePath}`);
+	}
+}
+
+function formatPrompt(system: string, user: string) {
+	return `# SYSTEM\n\n${system}\n\n# USER\n\n${user}`;
+}
+
+function printHits(hits: SearchHit[]) {
+	for (const [index, hit] of hits.entries()) {
+		console.log(`${index + 1}. ${hit.title}`);
+		console.log(
+			`   score=${hit.score.toFixed(2)} tier=${hit.tier}/${hit.kind}`,
+		);
+		console.log(`   source=${hit.sourcePath}`);
+		console.log(`   ${hit.snippet}\n`);
+	}
+}
+
+function printInventory(docs: ZirpDoc[], includeJournal: boolean) {
+	console.log(`divesh_zirp corpus: ${docs.length.toLocaleString()} docs`);
+	console.log(`notes root: ${NOTES_ROOT}`);
+	console.log(`journal included: ${includeJournal ? "yes" : "no"}\n`);
+	const groups = new Map<string, number>();
+	for (const doc of docs) {
+		const key = `${doc.tier}/${doc.kind}`;
+		groups.set(key, (groups.get(key) ?? 0) + 1);
+	}
+	for (const [key, count] of [...groups.entries()].sort(
+		(a, b) => b[1] - a[1],
+	)) {
+		console.log(`${key.padEnd(28)} ${count}`);
+	}
+}
+
+function walk(root: string, maxDepth: number) {
+	const files: string[] = [];
+	if (!existsSync(root)) return files;
+	visit(root, 0, files, maxDepth);
+	return files;
+}
+
+function visit(path: string, depth: number, files: string[], maxDepth: number) {
+	if (depth > maxDepth) return;
+	const stat = statSync(path);
+	if (stat.isFile()) {
+		files.push(path);
+		return;
+	}
+	if (!stat.isDirectory()) return;
+	for (const entry of readdirSync(path)) {
+		if (
+			entry.startsWith(".") ||
+			["node_modules", "dist", "Archive", "Legal", "Data"].includes(entry)
+		)
+			continue;
+		visit(join(path, entry), depth + 1, files, maxDepth);
+	}
+}
+
+function parseCsv(input: string) {
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let field = "";
+	let inQuotes = false;
+
+	for (let index = 0; index < input.length; index += 1) {
+		const char = input[index];
+		const next = input[index + 1];
+		if (char === '"' && inQuotes && next === '"') {
+			field += '"';
+			index += 1;
+		} else if (char === '"') {
+			inQuotes = !inQuotes;
+		} else if (char === "," && !inQuotes) {
+			row.push(field);
+			field = "";
+		} else if ((char === "\n" || char === "\r") && !inQuotes) {
+			if (char === "\r" && next === "\n") index += 1;
+			row.push(field);
+			rows.push(row);
+			row = [];
+			field = "";
+		} else {
+			field += char;
+		}
+	}
+
+	if (field || row.length > 0) {
+		row.push(field);
+		rows.push(row);
+	}
+
+	const [headers = [], ...body] = rows;
+	return body.map((values) =>
+		Object.fromEntries(
+			headers.map((header, index) => [header, values[index] ?? ""]),
+		),
+	);
+}
+
+function isMarkdown(path: string) {
+	return extname(path).toLowerCase() === ".md";
+}
+
+function titleFromPath(path: string) {
+	return basename(path, extname(path)).replace(/[-_]/g, " ");
+}
+
+function trimChars(text: string, limit: number) {
+	return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});


### PR DESCRIPTION
# PR: Add local-first `divesh_zirp` personal oracle v0

## Summary

This PR adds `divesh_zirp`: a local-first personal oracle for querying Divesh's writing, taste corpus, saved resources, and founder context.

Inspired by Venkatesh Rao's `vgr_zirp`, this v0 keeps the architecture intentionally simple and private: weighted local retrieval, explicit persona docs, source citations, and optional LLM answering only when `ANTHROPIC_API_KEY` is configured.

## Why

The blog repo already has the raw material for a personal ZIRP:

- self-authored essays/waves about games, feedback loops, spirituality, identity, and founding;
- a local Readwise/Zotero knowledge DB;
- Goodreads and Spotify exports that capture long-running taste signals;
- Versa strategy/sales/fundraising notes that capture the current operator context.

`divesh_zirp` makes that corpus queryable as a living mirror:

- “What do I actually believe?”
- “What should I write next?”
- “Connect WoW, feedback loops, and Versa.”
- “What does my saved reading imply about my taste?”
- “Turn this rough thought into a Divesh-shaped essay frame.”

## Inspiration

The shape comes from [`vgr_zirp`](https://ribbonfarm.com/vgr_zirp_tech/):

1. corpus-grounded answers;
2. retrieval before generation;
3. a “soul document” persona layer;
4. explicit style/lexicon artifacts instead of vague prompting.

This repo's version adapts that pattern for a private, local-first personal corpus.

## What changed

- Added `scripts/zirp.ts`
  - `inventory` — counts local corpus docs by tier/kind.
  - `search` — weighted local lexical retrieval with source snippets.
  - `prompt` — composes a full prompt with retrieved sources + persona docs.
  - `ask` — calls Anthropic if `ANTHROPIC_API_KEY` exists; otherwise prints the prompt.
- Added `bun zirp` package script.
- Added seed persona docs:
  - `docs/zirp/SOUL.md`
  - `docs/zirp/STYLE.md`
  - `docs/zirp/LEXICON.md`
- Added architecture and future docs:
  - `docs/zirp/README.md`
  - `docs/zirp/ARCHITECTURE.md`
  - `docs/zirp/SQLITE_PLAN.md`

## Corpus tiers

| Tier | Sources | Weight |
| --- | --- | ---: |
| Self-authored | Blog essays, waves, about page | 1.30 |
| Personal notes | `personal/`, `resources/`, root notes, projects | 1.15 |
| Operator notes | Versa strategy, sales, fundraising | 1.05 |
| Library metadata | Readwise/Zotero from `knowledge.db` | 0.75 |
| Books | Goodreads CSV | 0.70 |
| Music | Spotify export | 0.55 |

## Privacy defaults

- `journal/` is excluded unless `--include-journal` is passed.
- Existing `data/knowledge.db` is opened read-only/immutable.
- Source notes are never modified.
- Legal/data archive folders are not crawled.
- Network calls only happen for `ask`, and only if `ANTHROPIC_API_KEY` exists.

## Example commands

```bash
bun zirp inventory
bun zirp search "games as training grounds"
bun zirp prompt "connect WoW, feedback loops, and Versa"
bun zirp ask "what should I write next?"
```

## Validation

```bash
bunx biome check scripts/zirp.ts package.json
bun check
```

Both pass.

## Follow-up

The obvious next move is a dedicated ZIRP layer inside the existing `data/knowledge.db`:

- namespaced `zirp_*` source and chunk tables;
- FTS5 search;
- source hashing and incremental indexing;
- prompt run logging;
- later: embeddings via `sqlite-vec` or a compatible vector layer.

This keeps one local knowledge DB while clearly separating synced source data from derived oracle index data.

See `docs/zirp/SQLITE_PLAN.md`.
