### PR TITLE
Add divesh_zirp DX guide and model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
 ```
 
-Privacy defaults: `journal/` is excluded unless `--include-journal` is passed; API calls only happen when `ANTHROPIC_API_KEY` exists.
+Privacy defaults: `journal/` is excluded unless `--include-journal` is passed; API calls only happen when a model API key is configured. `ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present, with Anthropic fallback.
 
-See `docs/zirp/README.md` and `docs/zirp/ARCHITECTURE.md`.
+See `docs/zirp/README.md`, `docs/zirp/DX.md`, and `docs/zirp/ARCHITECTURE.md`.
 
 ## Content
 

--- a/docs/zirp/ARCHITECTURE.md
+++ b/docs/zirp/ARCHITECTURE.md
@@ -48,7 +48,7 @@ bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
 ```
 
-`ask` calls Anthropic only if `ANTHROPIC_API_KEY` is present. Otherwise it prints the composed prompt for copy/paste into any model.
+`ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present. If OpenAI is not configured, it falls back to Anthropic when `ANTHROPIC_API_KEY` is present. Otherwise it prints the composed prompt for copy/paste into any model.
 
 ## Privacy defaults
 

--- a/docs/zirp/DX.md
+++ b/docs/zirp/DX.md
@@ -1,0 +1,298 @@
+# divesh_zirp DX walkthrough
+
+This is the daily-use runbook for the local oracle.
+
+## Mental model
+
+`divesh_zirp` has three layers:
+
+1. **Sources** — blog posts, selected vault notes, Versa notes, Readwise/Zotero metadata, Goodreads, Spotify.
+2. **SQLite index** — derived `zirp_*` tables inside `data/knowledge.db`.
+3. **Prompt/answer layer** — retrieved snippets + `SOUL.md` + `STYLE.md` + `LEXICON.md`, optionally sent to a model.
+
+The source-of-truth tables stay untouched:
+
+```txt
+resources
+tags
+resource_tags
+sync_state
+```
+
+The rebuildable oracle layer lives next to them:
+
+```txt
+zirp_sources
+zirp_chunks
+zirp_chunks_fts
+zirp_runs
+zirp_run_sources
+zirp_embeddings
+zirp_exclusions
+```
+
+## First setup after clone or merge
+
+```bash
+cd ~/code/blog
+bun install
+bun sync --export-library   # if data/knowledge.db needs to be regenerated
+bun zirp init-db
+bun zirp index
+bun zirp stats
+```
+
+Expected shape after indexing:
+
+```txt
+zirp sources: ~11k
+zirp chunks:  ~11k+
+```
+
+Counts will drift as Readwise/Zotero/Spotify/Goodreads change.
+
+## Daily use
+
+### Inventory the live corpus
+
+```bash
+bun zirp inventory
+```
+
+This reads sources directly from disk/DB and shows what would be indexed. It does not require the SQLite ZIRP index.
+
+### Rebuild the index
+
+```bash
+bun zirp index
+```
+
+Run after:
+
+- editing blog posts;
+- adding notes;
+- syncing Readwise/Zotero;
+- changing Goodreads/Spotify exports.
+
+### Search sources
+
+```bash
+bun zirp search "games as training grounds"
+```
+
+This uses the SQLite FTS index by default when present.
+
+Force the original in-memory v0 path:
+
+```bash
+bun zirp search "games as training grounds" --memory
+```
+
+### Build a model prompt without calling an API
+
+```bash
+bun zirp prompt "connect WoW, feedback loops, and Versa"
+```
+
+This prints:
+
+- system prompt;
+- `SOUL.md` / `LEXICON.md` / `STYLE.md`;
+- retrieved snippets;
+- user question.
+
+Useful for debugging or copy/pasting into another model.
+
+### Ask the oracle
+
+```bash
+bun zirp ask "what is the hidden game I keep trying to play?"
+```
+
+If an API key is configured, this calls a model. If no key is found, it prints the prompt instead.
+
+## Model defaults
+
+Default model behavior is:
+
+1. If `OPENAI_API_KEY` exists, use **OpenAI `gpt-5.5` with reasoning effort `low`**.
+2. Otherwise, if `ANTHROPIC_API_KEY` exists, use **Claude Haiku**.
+3. If neither key exists, print the prompt.
+
+Override per command:
+
+```bash
+bun zirp ask "what should I write next?" \
+  --provider openai \
+  --model gpt-5.5 \
+  --reasoning-effort low
+```
+
+The shorthand model aliases `5.5`, `gpt55`, and `gpt-55` normalize to `gpt-5.5`.
+
+Override via env:
+
+```bash
+export ZIRP_PROVIDER=openai
+export ZIRP_MODEL=gpt-5.5
+export ZIRP_REASONING_EFFORT=low
+bun zirp ask "give me five essay ideas only I could write"
+```
+
+Anthropic override:
+
+```bash
+bun zirp ask "summarize my recurring obsessions" \
+  --provider anthropic \
+  --model claude-haiku-4-5-20251001
+```
+
+## Golden queries
+
+Use these as smoke tests after indexing.
+
+```bash
+bun zirp search "games as training grounds" --limit 5
+bun zirp search "feedback loops and pressure" --limit 5
+bun zirp search "Panama wedge commerce identity" --limit 5
+bun zirp prompt "connect Melee, WoW, and Versa into an essay thesis"
+bun zirp ask "what are my recurring obsessions?"
+bun zirp ask "explain Versa using my native game metaphors"
+bun zirp ask "what should I write next based on my corpus?"
+```
+
+## Fun experiments
+
+### Mirror test
+
+```bash
+bun zirp ask "what do I seem to believe that I have not stated directly?"
+```
+
+### Essay shaper
+
+```bash
+bun zirp ask "turn feedback as force into a sharper blog intro"
+```
+
+### Taste oracle
+
+```bash
+bun zirp ask "what does my reading and music taste suggest about my aesthetic?"
+```
+
+### Founder frame
+
+```bash
+bun zirp ask "what is the hidden game Versa is playing?"
+```
+
+### Retrieval comparison
+
+```bash
+bun zirp search "feedback loops and pressure" --limit 5
+bun zirp search "feedback loops and pressure" --limit 5 --memory
+```
+
+## Private mode
+
+By default, `journal/` is excluded.
+
+To include it:
+
+```bash
+bun zirp index --include-journal
+bun zirp ask "what emotional patterns keep repeating?"
+```
+
+Treat this as spicy mode. Rebuild without it when done:
+
+```bash
+bun zirp index
+```
+
+## Reset / rebuild
+
+Rebuild derived ZIRP tables without touching source-of-truth library tables:
+
+```bash
+sqlite3 data/knowledge.db <<'SQL'
+DELETE FROM zirp_run_sources;
+DELETE FROM zirp_runs;
+DELETE FROM zirp_embeddings;
+DELETE FROM zirp_chunks_fts;
+DELETE FROM zirp_chunks;
+DELETE FROM zirp_sources;
+SQL
+
+bun zirp index
+```
+
+Hard reset schema:
+
+```bash
+sqlite3 data/knowledge.db <<'SQL'
+DROP TABLE IF EXISTS zirp_run_sources;
+DROP TABLE IF EXISTS zirp_runs;
+DROP TABLE IF EXISTS zirp_embeddings;
+DROP TABLE IF EXISTS zirp_chunks_fts;
+DROP TABLE IF EXISTS zirp_chunks;
+DROP TABLE IF EXISTS zirp_sources;
+DROP TABLE IF EXISTS zirp_exclusions;
+SQL
+
+bun zirp init-db
+bun zirp index
+```
+
+## Troubleshooting
+
+### `data/knowledge.db not found`
+
+Run the sync/export pipeline first:
+
+```bash
+bun sync --export-library
+```
+
+### Search feels stale
+
+Rebuild:
+
+```bash
+bun zirp index
+```
+
+### Ask prints a prompt instead of answering
+
+No API key was found for the selected provider. Add one:
+
+```bash
+export OPENAI_API_KEY=...
+# or
+export ANTHROPIC_API_KEY=...
+```
+
+### Search quality seems weird
+
+Try:
+
+```bash
+bun zirp search "your query" --memory
+```
+
+If in-memory is better, the FTS query/re-ranker may need tuning.
+
+### Too much private context
+
+Rebuild without journal:
+
+```bash
+bun zirp index
+```
+
+Then inspect stats:
+
+```bash
+bun zirp stats
+```

--- a/docs/zirp/PR.md
+++ b/docs/zirp/PR.md
@@ -4,7 +4,7 @@
 
 This PR adds `divesh_zirp`: a local-first personal oracle for querying Divesh's writing, taste corpus, saved resources, and founder context.
 
-Inspired by Venkatesh Rao's `vgr_zirp`, this v0 keeps the architecture intentionally simple and private: weighted local retrieval, explicit persona docs, source citations, and optional LLM answering only when `ANTHROPIC_API_KEY` is configured.
+Inspired by Venkatesh Rao's `vgr_zirp`, this v0 keeps the architecture intentionally simple and private: weighted local retrieval, explicit persona docs, source citations, and optional LLM answering only when a model API key is configured.
 
 ## Why
 
@@ -40,7 +40,7 @@ This repo's version adapts that pattern for a private, local-first personal corp
   - `inventory` — counts local corpus docs by tier/kind.
   - `search` — weighted local lexical retrieval with source snippets.
   - `prompt` — composes a full prompt with retrieved sources + persona docs.
-  - `ask` — calls Anthropic if `ANTHROPIC_API_KEY` exists; otherwise prints the prompt.
+  - `ask` — calls a configured model API if available; otherwise prints the prompt.
 - Added `bun zirp` package script.
 - Added seed persona docs:
   - `docs/zirp/SOUL.md`
@@ -68,7 +68,7 @@ This repo's version adapts that pattern for a private, local-first personal corp
 - Existing `data/knowledge.db` is opened read-only/immutable.
 - Source notes are never modified.
 - Legal/data archive folders are not crawled.
-- Network calls only happen for `ask`, and only if `ANTHROPIC_API_KEY` exists.
+- Network calls only happen for `ask`, and only if `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` exists.
 
 ## Example commands
 

--- a/docs/zirp/README.md
+++ b/docs/zirp/README.md
@@ -45,6 +45,7 @@ The goal is not to build a generic chatbot. The goal is to make the corpus query
 - `docs/zirp/LEXICON.md` — seed glossary of recurring personal concepts.
 - `docs/zirp/ARCHITECTURE.md` — technical architecture and corpus tiering.
 - `docs/zirp/SQLITE_PLAN.md` — follow-up plan for namespaced ZIRP tables in the existing SQLite DB.
+- `docs/zirp/DX.md` — daily-use walkthrough, model config, golden queries, and troubleshooting.
 
 ## Commands
 
@@ -58,7 +59,13 @@ bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
 ```
 
-`ask` uses `ANTHROPIC_API_KEY` when present. If no key is configured, it prints the generated prompt so it can be pasted into any model.
+`ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present. If OpenAI is not configured, it falls back to Anthropic when `ANTHROPIC_API_KEY` is present. If no key is configured, it prints the generated prompt so it can be pasted into any model.
+
+Override per command:
+
+```bash
+bun zirp ask "what should I write next?" --provider openai --model gpt-5.5 --reasoning-effort low
+```
 
 ## Corpus tiers
 
@@ -77,7 +84,7 @@ bun zirp ask "what should I write next?"
 - Legal/data archive folders are not crawled.
 - Existing `data/knowledge.db` is opened read-only/immutable.
 - The CLI never modifies source notes.
-- Network calls only happen in `ask`, and only when `ANTHROPIC_API_KEY` exists.
+- Network calls only happen in `ask`, and only when `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` exists.
 
 ## Current limits
 

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -8,7 +8,17 @@ import { basename, extname, join, relative, resolve } from "node:path";
 const BLOG_ROOT = resolve(import.meta.dir, "..");
 const NOTES_ROOT = process.env.NOTES_ROOT ?? "/Users/dpunj/notes";
 const KNOWLEDGE_DB_PATH = join(BLOG_ROOT, "data/knowledge.db");
-const DEFAULT_MODEL = process.env.ZIRP_MODEL ?? "claude-haiku-4-5-20251001";
+const DEFAULT_OPENAI_MODEL = "gpt-5.5";
+const DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_REASONING_EFFORT = "low";
+
+type ZirpProvider = "openai" | "anthropic";
+
+type ModelConfig = {
+	provider: ZirpProvider;
+	model: string;
+	reasoningEffort: "minimal" | "low" | "medium" | "high";
+};
 
 type CorpusTier =
 	| "self"
@@ -87,12 +97,14 @@ Commands:
   bun zirp stats
   bun zirp search <query> [--limit 8] [--include-journal] [--memory]
   bun zirp prompt <query> [--include-journal] [--memory]
-  bun zirp ask <query> [--include-journal] [--memory]
+  bun zirp ask <query> [--include-journal] [--memory] [--provider openai|anthropic] [--model gpt-5.5] [--reasoning-effort low]
 
 Notes:
   - journal/ is excluded unless --include-journal is passed.
   - search/prompt/ask prefer the SQLite index when available; use --memory to force v0 in-memory search.
-  - ask uses ANTHROPIC_API_KEY if present; otherwise it prints the prompt.`);
+  - ask defaults to OpenAI GPT-5.5 with reasoning effort low when OPENAI_API_KEY is present.
+  - set ZIRP_PROVIDER/ZIRP_MODEL/ZIRP_REASONING_EFFORT or pass flags to override.
+  - if no configured API key is found, ask prints the prompt.`);
 }
 
 async function main() {
@@ -106,6 +118,7 @@ async function main() {
 
 	const includeJournal = cli.flags.has("include-journal");
 	const forceMemory = cli.flags.has("memory");
+	const modelConfig = getModelConfig(cli);
 	const requestedLimit = Number(cli.values.get("limit") ?? 8);
 	const limit = Number.isFinite(requestedLimit) ? requestedLimit : 8;
 	const query = cli.positionals.slice(1).join(" ").trim();
@@ -155,13 +168,13 @@ async function main() {
 	}
 
 	if (command === "ask") {
-		const responseText = await ask(query, hits);
+		const responseText = await ask(query, hits, modelConfig);
 		recordZirpRun(
 			"ask",
 			query,
 			hits,
 			responseText,
-			process.env.ANTHROPIC_API_KEY ? DEFAULT_MODEL : undefined,
+			formatModelLabel(modelConfig),
 		);
 		return;
 	}
@@ -192,6 +205,51 @@ function parseCliArgs(args: string[]) {
 	}
 
 	return { flags, values, positionals };
+}
+
+function getModelConfig(cli: ReturnType<typeof parseCliArgs>): ModelConfig {
+	const provider = normalizeProvider(
+		cli.values.get("provider") ?? process.env.ZIRP_PROVIDER,
+	);
+	const model = normalizeModelName(
+		cli.values.get("model") ??
+			process.env.ZIRP_MODEL ??
+			(provider === "openai" ? DEFAULT_OPENAI_MODEL : DEFAULT_ANTHROPIC_MODEL),
+	);
+	const reasoningEffort = normalizeReasoningEffort(
+		cli.values.get("reasoning-effort") ??
+			process.env.ZIRP_REASONING_EFFORT ??
+			DEFAULT_REASONING_EFFORT,
+	);
+	return { provider, model, reasoningEffort };
+}
+
+function normalizeProvider(value?: string): ZirpProvider {
+	if (value === "anthropic") return "anthropic";
+	if (value === "openai") return "openai";
+	return process.env.OPENAI_API_KEY ? "openai" : "anthropic";
+}
+
+function normalizeModelName(model: string) {
+	if (["5.5", "gpt55", "gpt-55"].includes(model.toLowerCase())) {
+		return "gpt-5.5";
+	}
+	return model;
+}
+
+function normalizeReasoningEffort(
+	value: string,
+): ModelConfig["reasoningEffort"] {
+	if (["minimal", "low", "medium", "high"].includes(value)) {
+		return value as ModelConfig["reasoningEffort"];
+	}
+	return DEFAULT_REASONING_EFFORT;
+}
+
+function formatModelLabel(config: ModelConfig) {
+	return config.provider === "openai"
+		? `${config.provider}:${config.model}:reasoning=${config.reasoningEffort}`
+		: `${config.provider}:${config.model}`;
 }
 
 function loadCorpus(includeJournal: boolean) {
@@ -952,15 +1010,93 @@ function readPersona(file: string) {
 	return existsSync(path) ? readFileSync(path, "utf8") : "";
 }
 
-async function ask(query: string, hits: SearchHit[]) {
-	const prompt = buildPrompt(query, hits);
-	const apiKey = process.env.ANTHROPIC_API_KEY;
+type OpenAIResponse = {
+	output_text?: string;
+	output?: {
+		content?: { text?: string; type?: string }[];
+	}[];
+};
 
-	if (!apiKey) {
-		console.log("ANTHROPIC_API_KEY not found. Printing prompt instead.\n");
+function extractOpenAIText(body: OpenAIResponse) {
+	if (body.output_text) return body.output_text;
+	return (
+		body.output
+			?.flatMap((item) => item.content ?? [])
+			.map((content) => content.text)
+			.filter(Boolean)
+			.join("\n") ?? ""
+	);
+}
+
+async function ask(query: string, hits: SearchHit[], modelConfig: ModelConfig) {
+	const prompt = buildPrompt(query, hits);
+	const responseText = await callModel(prompt, modelConfig);
+
+	if (!responseText) {
+		console.log(
+			`No API key found for ${modelConfig.provider}. Printing prompt instead.\n`,
+		);
 		console.log(formatPrompt(prompt.system, prompt.user));
 		return "";
 	}
+
+	console.log(responseText);
+	console.log("\nSources:");
+	for (const [index, hit] of hits.entries()) {
+		console.log(`${index + 1}. ${hit.title} — ${hit.sourcePath}`);
+	}
+	return responseText;
+}
+
+async function callModel(
+	prompt: { system: string; user: string },
+	modelConfig: ModelConfig,
+) {
+	if (modelConfig.provider === "openai") {
+		return callOpenAI(prompt, modelConfig);
+	}
+	return callAnthropic(prompt, modelConfig);
+}
+
+async function callOpenAI(
+	prompt: { system: string; user: string },
+	modelConfig: ModelConfig,
+) {
+	const apiKey = process.env.OPENAI_API_KEY;
+	if (!apiKey) return "";
+
+	const response = await fetch("https://api.openai.com/v1/responses", {
+		method: "POST",
+		headers: {
+			authorization: `Bearer ${apiKey}`,
+			"content-type": "application/json",
+		},
+		body: JSON.stringify({
+			model: modelConfig.model,
+			max_output_tokens: 900,
+			reasoning: { effort: modelConfig.reasoningEffort },
+			input: [
+				{ role: "system", content: prompt.system },
+				{ role: "user", content: prompt.user },
+			],
+		}),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`OpenAI request failed: ${response.status} ${body}`);
+	}
+
+	const body = (await response.json()) as OpenAIResponse;
+	return extractOpenAIText(body);
+}
+
+async function callAnthropic(
+	prompt: { system: string; user: string },
+	modelConfig: ModelConfig,
+) {
+	const apiKey = process.env.ANTHROPIC_API_KEY;
+	if (!apiKey) return "";
 
 	const response = await fetch("https://api.anthropic.com/v1/messages", {
 		method: "POST",
@@ -970,7 +1106,7 @@ async function ask(query: string, hits: SearchHit[]) {
 			"x-api-key": apiKey,
 		},
 		body: JSON.stringify({
-			model: DEFAULT_MODEL,
+			model: modelConfig.model,
 			max_tokens: 900,
 			system: prompt.system,
 			messages: [{ role: "user", content: prompt.user }],
@@ -983,17 +1119,12 @@ async function ask(query: string, hits: SearchHit[]) {
 	}
 
 	const body = (await response.json()) as { content?: { text?: string }[] };
-	const responseText =
+	return (
 		body.content
 			?.map((part) => part.text)
 			.filter(Boolean)
-			.join("\n") ?? "";
-	console.log(responseText);
-	console.log("\nSources:");
-	for (const [index, hit] of hits.entries()) {
-		console.log(`${index + 1}. ${hit.title} — ${hit.sourcePath}`);
-	}
-	return responseText;
+			.join("\n") ?? ""
+	);
 }
 
 function formatPrompt(system: string, user: string) {


### PR DESCRIPTION
## Summary

Adds a proper `divesh_zirp` DX walkthrough and model configuration for `ask`.

## What changed

- Adds `docs/zirp/DX.md` with:
  - first setup ritual;
  - daily use;
  - SQLite index lifecycle;
  - model config;
  - golden queries;
  - fun experiments;
  - private journal mode;
  - reset/rebuild commands;
  - troubleshooting.
- Updates docs/README references to the DX guide.
- Adds model/provider config to `bun zirp ask`:
  - `--provider openai|anthropic`
  - `--model ...`
  - `--reasoning-effort minimal|low|medium|high`
- Defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present.
- Falls back to Anthropic Claude Haiku when OpenAI is not configured and `ANTHROPIC_API_KEY` exists.
- Keeps prompt-only behavior when no selected provider API key is available.
- Adds aliases: `5.5`, `gpt55`, and `gpt-55` normalize to `gpt-5.5`.

## Example

```bash
bun zirp ask "what should I write next?" \
  --provider openai \
  --model gpt-5.5 \
  --reasoning-effort low
```

Or via env:

```bash
export ZIRP_PROVIDER=openai
export ZIRP_MODEL=gpt-5.5
export ZIRP_REASONING_EFFORT=low
bun zirp ask "what is the hidden game I keep trying to play?"
```

## Validation

```bash
bunx biome check scripts/zirp.ts README.md docs/zirp
bun check
OPENAI_API_KEY= ANTHROPIC_API_KEY= bun zirp ask "what is the hidden game" --limit 1
bun zirp search "games as training grounds" --limit 2
```
