### PR TITLE
Add local divesh_zirp web cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Personal blog built with [Astro](https://astro.build).
 | `bun zirp inventory` | Inventory the local `divesh_zirp` corpus |
 | `bun zirp init-db` | Create namespaced `zirp_*` tables in `data/knowledge.db` |
 | `bun zirp index` | Build the local SQLite/FTS oracle index |
+| `bun zirp serve` | Open the local `divesh_zirp` web cockpit on `127.0.0.1:7331` |
 | `bun zirp search "games as training grounds"` | Search the personal oracle corpus |
 | `bun zirp ask "what should I write next?"` | Ask the oracle; uses Anthropic if configured, otherwise prints the prompt |
 
@@ -97,6 +98,7 @@ bun zirp inventory
 bun zirp init-db
 bun zirp index
 bun zirp stats
+bun zirp serve
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
@@ -104,7 +106,7 @@ bun zirp ask "what should I write next?"
 
 Privacy defaults: `journal/` is excluded unless `--include-journal` is passed; API calls only happen when a model API key is configured. `ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present, with Anthropic fallback.
 
-See `docs/zirp/README.md`, `docs/zirp/DX.md`, and `docs/zirp/ARCHITECTURE.md`.
+See `docs/zirp/README.md`, `docs/zirp/DX.md`, `docs/zirp/WEB_CLIENT.md`, and `docs/zirp/ARCHITECTURE.md`.
 
 ## Content
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Personal blog built with [Astro](https://astro.build).
 | `bun zirp inventory` | Inventory the local `divesh_zirp` corpus |
 | `bun zirp init-db` | Create namespaced `zirp_*` tables in `data/knowledge.db` |
 | `bun zirp index` | Build the local SQLite/FTS oracle index |
-| `bun zirp serve` | Open the local `divesh_zirp` web cockpit on `127.0.0.1:7331` |
+| `bun zirp serve` | Open the local `divesh_zirp` web cockpit + SQLite explorer on `127.0.0.1:7331` |
 | `bun zirp search "games as training grounds"` | Search the personal oracle corpus |
 | `bun zirp ask "what should I write next?"` | Ask the oracle; uses Anthropic if configured, otherwise prints the prompt |
 
@@ -99,6 +99,7 @@ bun zirp init-db
 bun zirp index
 bun zirp stats
 bun zirp serve
+bun zirp datasette
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"

--- a/docs/zirp/ARCHITECTURE.md
+++ b/docs/zirp/ARCHITECTURE.md
@@ -43,6 +43,7 @@ bun zirp inventory
 bun zirp init-db
 bun zirp index
 bun zirp stats
+bun zirp serve
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"

--- a/docs/zirp/DX.md
+++ b/docs/zirp/DX.md
@@ -42,6 +42,13 @@ bun zirp index
 bun zirp stats
 ```
 
+Open the local cockpit:
+
+```bash
+bun zirp serve
+# http://127.0.0.1:7331
+```
+
 Expected shape after indexing:
 
 ```txt
@@ -110,6 +117,14 @@ bun zirp ask "what is the hidden game I keep trying to play?"
 ```
 
 If an API key is configured, this calls a model. If no key is found, it prints the prompt instead.
+
+### Use the web cockpit
+
+```bash
+bun zirp serve
+```
+
+Then open `http://127.0.0.1:7331`. The cockpit gives you search, ask, prompt inspection, stats, and run history in one local UI.
 
 ## Model defaults
 

--- a/docs/zirp/DX.md
+++ b/docs/zirp/DX.md
@@ -124,7 +124,7 @@ If an API key is configured, this calls a model. If no key is found, it prints t
 bun zirp serve
 ```
 
-Then open `http://127.0.0.1:7331`. The cockpit gives you search, ask, prompt inspection, stats, and run history in one local UI.
+Then open `http://127.0.0.1:7331`. The cockpit gives you search, ask, prompt inspection, stats, run history, table browsing, and a read-only SQL scratchpad in one local UI.
 
 ## Model defaults
 

--- a/docs/zirp/README.md
+++ b/docs/zirp/README.md
@@ -46,6 +46,7 @@ The goal is not to build a generic chatbot. The goal is to make the corpus query
 - `docs/zirp/ARCHITECTURE.md` — technical architecture and corpus tiering.
 - `docs/zirp/SQLITE_PLAN.md` — follow-up plan for namespaced ZIRP tables in the existing SQLite DB.
 - `docs/zirp/DX.md` — daily-use walkthrough, model config, golden queries, and troubleshooting.
+- `docs/zirp/WEB_CLIENT.md` — local web cockpit and public-facing oracle plan.
 
 ## Commands
 
@@ -54,6 +55,7 @@ bun zirp inventory
 bun zirp init-db
 bun zirp index
 bun zirp stats
+bun zirp serve
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"

--- a/docs/zirp/WEB_CLIENT.md
+++ b/docs/zirp/WEB_CLIENT.md
@@ -1,0 +1,81 @@
+# divesh_zirp web client
+
+`bun zirp serve` runs a local web cockpit for the SQLite-backed oracle.
+
+```bash
+bun zirp serve
+# opens http://127.0.0.1:7331
+```
+
+It is intentionally local-only by default. The server binds to `127.0.0.1` unless you override `--host`.
+
+## What it does
+
+- Search the indexed corpus.
+- Ask the oracle with the same model defaults as the CLI.
+- Generate and inspect prompts.
+- Show index stats.
+- Show recent `zirp_runs`.
+- Display source cards with snippets and paths.
+
+## Model behavior
+
+Same as CLI:
+
+1. `OPENAI_API_KEY` → OpenAI `gpt-5.5`, reasoning effort `low`.
+2. `ANTHROPIC_API_KEY` → Claude Haiku fallback.
+3. No key → return generated prompt instead of answer.
+
+The UI exposes provider/model/reasoning controls per request.
+
+## Local API
+
+```txt
+GET  /api/stats
+GET  /api/runs
+POST /api/search
+POST /api/prompt
+POST /api/ask
+```
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:7331/api/search \
+  -H 'content-type: application/json' \
+  -d '{"query":"games as training grounds","limit":5}'
+```
+
+## Public-facing path
+
+The current web client is a **private local cockpit**, not the public blog oracle.
+
+For publishing `divesh_zirp` publicly, keep a hard boundary:
+
+| Surface | Corpus | Auth | Notes |
+| --- | --- | --- | --- |
+| Local cockpit | Full local corpus, optional journal | localhost | Private research/building tool. |
+| Public oracle | Blog posts + explicitly curated public notes only | rate-limited | Safe to embed on `divesh.gg`. |
+| Private oracle | Full personal corpus | authenticated | Only if needed later. |
+
+Public launch requirements:
+
+- Build a separate public-safe index from `self` sources only by default.
+- Exclude `personal`, `operator`, `journal`, legal/data exports, and private Readwise metadata unless explicitly allowlisted.
+- Add rate limiting and cost controls.
+- Add source visibility labels.
+- Add a public system prompt that says it is a corpus-grounded oracle, not Divesh.
+- Add a privacy checklist before deploy.
+
+## Suggested public UX
+
+A future `/zirp` page on the blog should be simpler than the local cockpit:
+
+- one beautiful question box;
+- a few suggested prompts;
+- answer + citations;
+- source chips linking to public posts;
+- “what is this?” explainer;
+- no private stats, runs, prompt inspector, or journal mode.
+
+The local cockpit is for power use. The public oracle is for readers.

--- a/docs/zirp/WEB_CLIENT.md
+++ b/docs/zirp/WEB_CLIENT.md
@@ -17,6 +17,8 @@ It is intentionally local-only by default. The server binds to `127.0.0.1` unles
 - Show index stats.
 - Show recent `zirp_runs`.
 - Display source cards with snippets and paths.
+- Browse SQLite tables through a lightweight native `bun:sqlite` explorer.
+- Run read-only SQL scratchpad queries (`SELECT` / `WITH` / `PRAGMA`).
 
 ## Model behavior
 
@@ -33,10 +35,15 @@ The UI exposes provider/model/reasoning controls per request.
 ```txt
 GET  /api/stats
 GET  /api/runs
+GET  /api/db/tables
+GET  /api/db/table?name=zirp_sources&limit=50
+POST /api/db/query
 POST /api/search
 POST /api/prompt
 POST /api/ask
 ```
+
+The DB explorer uses Bun's native SQLite driver directly. Datasette is still great for deep external spelunking, but the cockpit has enough built-in DB access for quick local inspection.
 
 Example:
 

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -95,12 +95,14 @@ Commands:
   bun zirp init-db
   bun zirp index [--include-journal]
   bun zirp stats
+  bun zirp serve [--host 127.0.0.1] [--port 7331]
   bun zirp search <query> [--limit 8] [--include-journal] [--memory]
   bun zirp prompt <query> [--include-journal] [--memory]
   bun zirp ask <query> [--include-journal] [--memory] [--provider openai|anthropic] [--model gpt-5.5] [--reasoning-effort low]
 
 Notes:
   - journal/ is excluded unless --include-journal is passed.
+  - serve binds to 127.0.0.1 by default for privacy.
   - search/prompt/ask prefer the SQLite index when available; use --memory to force v0 in-memory search.
   - ask defaults to OpenAI GPT-5.5 with reasoning effort low when OPENAI_API_KEY is present.
   - set ZIRP_PROVIDER/ZIRP_MODEL/ZIRP_REASONING_EFFORT or pass flags to override.
@@ -139,6 +141,14 @@ async function main() {
 
 	if (command === "stats") {
 		printZirpStats();
+		return;
+	}
+
+	if (command === "serve") {
+		const host = cli.values.get("host") ?? "127.0.0.1";
+		const requestedPort = Number(cli.values.get("port") ?? 7331);
+		const port = Number.isFinite(requestedPort) ? requestedPort : 7331;
+		serveZirp({ host, port, includeJournal, forceMemory, modelConfig });
 		return;
 	}
 
@@ -615,6 +625,397 @@ function printZirpStats() {
 	} finally {
 		db.close();
 	}
+}
+
+type ServeOptions = {
+	host: string;
+	port: number;
+	includeJournal: boolean;
+	forceMemory: boolean;
+	modelConfig: ModelConfig;
+};
+
+function serveZirp(options: ServeOptions) {
+	const server = Bun.serve({
+		hostname: options.host,
+		port: options.port,
+		async fetch(request) {
+			const url = new URL(request.url);
+			try {
+				if (url.pathname === "/") return htmlResponse(renderZirpUi(options));
+				if (url.pathname === "/api/stats") return jsonResponse(getZirpStats());
+				if (url.pathname === "/api/runs") return jsonResponse(getRecentRuns());
+				if (url.pathname === "/api/search" && request.method === "POST") {
+					const body = await readJsonBody(request);
+					const query = String(body.query ?? "").trim();
+					const limit = readApiLimit(body.limit);
+					const hits = search(
+						query,
+						limit,
+						options.includeJournal,
+						Boolean(body.memory ?? options.forceMemory),
+					);
+					recordZirpRun("search", query, hits);
+					return jsonResponse({ hits: hits.map(toPublicHit) });
+				}
+				if (url.pathname === "/api/prompt" && request.method === "POST") {
+					const body = await readJsonBody(request);
+					const query = String(body.query ?? "").trim();
+					const limit = readApiLimit(body.limit);
+					const hits = search(
+						query,
+						limit,
+						options.includeJournal,
+						Boolean(body.memory ?? options.forceMemory),
+					);
+					const prompt = buildPrompt(query, hits);
+					recordZirpRun("prompt", query, hits);
+					return jsonResponse({ ...prompt, hits: hits.map(toPublicHit) });
+				}
+				if (url.pathname === "/api/ask" && request.method === "POST") {
+					const body = await readJsonBody(request);
+					const query = String(body.query ?? "").trim();
+					const limit = readApiLimit(body.limit);
+					const requestModel = getRequestModelConfig(body, options.modelConfig);
+					const hits = search(
+						query,
+						limit,
+						options.includeJournal,
+						Boolean(body.memory ?? options.forceMemory),
+					);
+					const prompt = buildPrompt(query, hits);
+					const answer = await callModel(prompt, requestModel);
+					recordZirpRun(
+						"ask",
+						query,
+						hits,
+						answer,
+						formatModelLabel(requestModel),
+					);
+					return jsonResponse({
+						answer,
+						prompt: answer ? undefined : prompt,
+						hits: hits.map(toPublicHit),
+						model: formatModelLabel(requestModel),
+						noKey: !answer,
+					});
+				}
+				return new Response("Not found", { status: 404 });
+			} catch (error) {
+				return jsonResponse(
+					{ error: error instanceof Error ? error.message : String(error) },
+					500,
+				);
+			}
+		},
+	});
+
+	console.log(
+		`divesh_zirp cockpit listening on http://${server.hostname}:${server.port}`,
+	);
+	console.log(
+		"Local-only by default. Use --host 0.0.0.0 only if you know what you are exposing.",
+	);
+}
+
+function getRequestModelConfig(
+	body: Record<string, unknown>,
+	fallback: ModelConfig,
+): ModelConfig {
+	return {
+		provider: normalizeProvider(
+			typeof body.provider === "string" ? body.provider : fallback.provider,
+		),
+		model: normalizeModelName(
+			typeof body.model === "string" ? body.model : fallback.model,
+		),
+		reasoningEffort: normalizeReasoningEffort(
+			typeof body.reasoningEffort === "string"
+				? body.reasoningEffort
+				: fallback.reasoningEffort,
+		),
+	};
+}
+
+async function readJsonBody(request: Request) {
+	if (!request.body) return {} as Record<string, unknown>;
+	return (await request.json()) as Record<string, unknown>;
+}
+
+function readApiLimit(value: unknown) {
+	const limit = Number(value ?? 8);
+	if (!Number.isFinite(limit)) return 8;
+	return Math.max(1, Math.min(20, limit));
+}
+
+function toPublicHit(hit: SearchHit) {
+	return {
+		id: hit.id,
+		title: hit.title,
+		sourcePath: hit.sourcePath,
+		tier: hit.tier,
+		kind: hit.kind,
+		score: Number(hit.score.toFixed(2)),
+		snippet: hit.snippet,
+	};
+}
+
+function getZirpStats() {
+	if (!existsSync(KNOWLEDGE_DB_PATH) || !hasZirpTables()) {
+		return { initialized: false, sources: 0, chunks: 0, runs: 0, tiers: [] };
+	}
+	const db = new Database(`file:${KNOWLEDGE_DB_PATH}?mode=ro&immutable=1`, {
+		readonly: true,
+	});
+	try {
+		const sources = db
+			.query("SELECT count(*) AS count FROM zirp_sources")
+			.get() as { count: number };
+		const chunks = db
+			.query("SELECT count(*) AS count FROM zirp_chunks")
+			.get() as { count: number };
+		const runs = db.query("SELECT count(*) AS count FROM zirp_runs").get() as {
+			count: number;
+		};
+		const tiers = db
+			.query(`
+				SELECT tier, source_type AS sourceType, count(*) AS count
+				FROM zirp_sources
+				GROUP BY tier, source_type
+				ORDER BY count DESC
+			`)
+			.all() as { tier: string; sourceType: string; count: number }[];
+		return {
+			initialized: true,
+			sources: sources.count,
+			chunks: chunks.count,
+			runs: runs.count,
+			tiers,
+		};
+	} finally {
+		db.close();
+	}
+}
+
+function getRecentRuns() {
+	if (!existsSync(KNOWLEDGE_DB_PATH) || !hasZirpTables()) return { runs: [] };
+	const db = new Database(`file:${KNOWLEDGE_DB_PATH}?mode=ro&immutable=1`, {
+		readonly: true,
+	});
+	try {
+		const runs = db
+			.query(`
+				SELECT id, created_at AS createdAt, mode, model, query
+				FROM zirp_runs
+				ORDER BY created_at DESC
+				LIMIT 20
+			`)
+			.all() as {
+			id: string;
+			createdAt: string;
+			mode: string;
+			model: string | null;
+			query: string;
+		}[];
+		return { runs };
+	} finally {
+		db.close();
+	}
+}
+
+function htmlResponse(html: string) {
+	return new Response(html, {
+		headers: { "content-type": "text/html; charset=utf-8" },
+	});
+}
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json; charset=utf-8" },
+	});
+}
+
+function renderZirpUi(options: ServeOptions) {
+	return `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>divesh_zirp cockpit</title>
+	<style>
+		:root { color-scheme: dark; --bg: #020617; --panel: #0f172a; --panel-2: #111827; --text: #e5e7eb; --muted: #94a3b8; --line: #1f2937; --accent: #38bdf8; --danger: #f87171; }
+		* { box-sizing: border-box; }
+		body { margin: 0; background: var(--bg); color: var(--text); font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+		button, input, textarea, select { font: inherit; }
+		button { border: 1px solid var(--line); border-radius: 12px; padding: 10px 14px; background: var(--panel-2); color: var(--text); cursor: pointer; }
+		button:hover { border-color: var(--accent); }
+		button.primary { background: var(--accent); border-color: var(--accent); color: #082f49; font-weight: 700; }
+		button:disabled { cursor: wait; opacity: 0.6; }
+		textarea, input, select { width: 100%; border: 1px solid var(--line); border-radius: 14px; background: #020617; color: var(--text); padding: 12px; }
+		textarea { min-height: 120px; resize: vertical; }
+		label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+		code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+		.shell { max-width: 1180px; margin: 0 auto; padding: 32px 20px 48px; }
+		.header { display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; margin-bottom: 24px; }
+		.eyebrow { color: var(--accent); font-size: 13px; font-weight: 700; text-transform: uppercase; }
+		h1 { margin: 4px 0 8px; font-size: clamp(32px, 6vw, 72px); line-height: 0.95; letter-spacing: -0.04em; }
+		p { color: var(--muted); max-width: 760px; }
+		.grid { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.6fr); gap: 18px; align-items: start; }
+		.card { border: 1px solid var(--line); border-radius: 22px; background: var(--panel); padding: 18px; }
+		.controls { display: grid; grid-template-columns: 1fr 150px 160px 110px; gap: 10px; margin: 12px 0; }
+		.actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+		.stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+		.stat { border: 1px solid var(--line); border-radius: 16px; padding: 12px; background: #020617; }
+		.stat strong { display: block; font-size: 22px; font-variant-numeric: tabular-nums; }
+		.result { border: 1px solid var(--line); border-radius: 16px; padding: 14px; margin-top: 12px; background: #020617; }
+		.result h3 { margin: 0 0 6px; font-size: 16px; }
+		.meta { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; }
+		.answer { white-space: pre-wrap; }
+		.prompt { max-height: 420px; overflow: auto; white-space: pre-wrap; }
+		.error { color: var(--danger); margin-top: 10px; }
+		.run { border-top: 1px solid var(--line); padding: 10px 0; }
+		.run:first-child { border-top: 0; }
+		@media (max-width: 880px) { .header, .grid { display: block; } .controls { grid-template-columns: 1fr; } .card { margin-top: 16px; } }
+	</style>
+</head>
+<body>
+	<div class="shell">
+		<header class="header">
+			<div>
+				<div class="eyebrow">local private cockpit</div>
+				<h1>divesh_zirp</h1>
+				<p>Search, prompt, and ask your local corpus. SQLite FTS first, persona docs on top, OpenAI 5.5 low by default when configured.</p>
+			</div>
+			<div class="card">
+				<div class="meta">Host</div>
+				<strong>${escapeHtml(options.host)}:${options.port}</strong>
+				<div class="meta">Model default</div>
+				<strong>${escapeHtml(formatModelLabel(options.modelConfig))}</strong>
+			</div>
+		</header>
+
+		<div class="grid">
+			<main class="card">
+				<label>Question
+					<textarea id="query">what is the hidden game I keep trying to play?</textarea>
+				</label>
+				<div class="controls">
+					<label>Provider<select id="provider"><option value="openai">openai</option><option value="anthropic">anthropic</option></select></label>
+					<label>Model<input id="model" value="${escapeHtml(options.modelConfig.model)}" /></label>
+					<label>Reasoning<select id="reasoning"><option>minimal</option><option selected>low</option><option>medium</option><option>high</option></select></label>
+					<label>Limit<input id="limit" type="number" min="1" max="20" value="8" /></label>
+				</div>
+				<div class="actions">
+					<button class="primary" id="ask">Ask</button>
+					<button id="search">Search</button>
+					<button id="prompt">Prompt</button>
+					<button id="clear">Clear</button>
+				</div>
+				<div id="error" class="error" role="alert"></div>
+				<section id="answer"></section>
+				<section id="results"></section>
+			</main>
+
+			<aside class="card">
+				<h2>Index</h2>
+				<div class="stats" id="stats"></div>
+				<h2>Recent runs</h2>
+				<div id="runs"></div>
+			</aside>
+		</div>
+	</div>
+
+	<script>
+		const $ = (id) => document.getElementById(id);
+		const provider = $("provider");
+		provider.value = "${options.modelConfig.provider}";
+		$("reasoning").value = "${options.modelConfig.reasoningEffort}";
+
+		async function post(path, body) {
+			const response = await fetch(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+			const json = await response.json();
+			if (!response.ok) throw new Error(json.error || "Request failed");
+			return json;
+		}
+
+		function payload() {
+			return { query: $("query").value, limit: Number($("limit").value || 8), provider: provider.value, model: $("model").value, reasoningEffort: $("reasoning").value };
+		}
+
+		function setBusy(busy) {
+			for (const id of ["ask", "search", "prompt"]) $(id).disabled = busy;
+		}
+
+		function renderHits(hits = []) {
+			$("results").innerHTML = hits.map((hit, index) => '<article class="result"><h3>' + (index + 1) + '. ' + escapeHtml(hit.title) + '</h3><div class="meta">' + escapeHtml(hit.tier + '/' + hit.kind) + ' · score ' + hit.score + '</div><div class="meta">' + escapeHtml(hit.sourcePath) + '</div><p>' + escapeHtml(hit.snippet) + '</p></article>').join("");
+		}
+
+		function renderAnswer(json) {
+			if (json.noKey) {
+				$("answer").innerHTML = '<article class="result"><h3>No API key found. Prompt generated instead.</h3><pre class="prompt">' + escapeHtml('# SYSTEM\\n\\n' + json.prompt.system + '\\n\\n# USER\\n\\n' + json.prompt.user) + '</pre></article>';
+			} else {
+				$("answer").innerHTML = '<article class="result"><h3>Answer</h3><div class="meta">' + escapeHtml(json.model || '') + '</div><div class="answer">' + escapeHtml(json.answer || '') + '</div></article>';
+			}
+			renderHits(json.hits);
+		}
+
+		async function run(mode) {
+			$("error").textContent = "";
+			setBusy(true);
+			try {
+				if (mode === "search") {
+					const json = await post("/api/search", payload());
+					$("answer").innerHTML = "";
+					renderHits(json.hits);
+				} else if (mode === "prompt") {
+					const json = await post("/api/prompt", payload());
+					$("answer").innerHTML = '<article class="result"><h3>Prompt</h3><pre class="prompt">' + escapeHtml('# SYSTEM\\n\\n' + json.system + '\\n\\n# USER\\n\\n' + json.user) + '</pre></article>';
+					renderHits(json.hits);
+				} else {
+					renderAnswer(await post("/api/ask", payload()));
+				}
+				await loadSidebars();
+			} catch (error) {
+				$("error").textContent = error.message;
+			} finally {
+				setBusy(false);
+			}
+		}
+
+		async function loadSidebars() {
+			const stats = await fetch("/api/stats").then((r) => r.json());
+			$("stats").innerHTML = ['sources','chunks','runs'].map((key) => '<div class="stat"><span class="meta">' + key + '</span><strong>' + Number(stats[key] || 0).toLocaleString() + '</strong></div>').join("");
+			const runs = await fetch("/api/runs").then((r) => r.json());
+			$("runs").innerHTML = (runs.runs || []).map((run) => '<div class="run"><div class="meta">' + escapeHtml(run.mode + ' · ' + (run.model || 'prompt')) + '</div><div>' + escapeHtml(run.query) + '</div></div>').join("") || '<p>No runs yet.</p>';
+		}
+
+		function escapeHtml(value) {
+			return String(value ?? "").replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[char]));
+		}
+
+		$("ask").addEventListener("click", () => run("ask"));
+		$("search").addEventListener("click", () => run("search"));
+		$("prompt").addEventListener("click", () => run("prompt"));
+		$("clear").addEventListener("click", () => { $("answer").innerHTML = ""; $("results").innerHTML = ""; $("error").textContent = ""; });
+		$("query").addEventListener("keydown", (event) => { if ((event.metaKey || event.ctrlKey) && event.key === "Enter") run("ask"); });
+		loadSidebars();
+	</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string | number) {
+	return String(value).replace(/[&<>"']/g, (char) => {
+		const entities: Record<string, string> = {
+			"&": "&amp;",
+			"<": "&lt;",
+			">": "&gt;",
+			'"': "&quot;",
+			"'": "&#39;",
+		};
+		return entities[char] ?? char;
+	});
 }
 
 function hasZirpTables() {

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -645,6 +645,20 @@ function serveZirp(options: ServeOptions) {
 				if (url.pathname === "/") return htmlResponse(renderZirpUi(options));
 				if (url.pathname === "/api/stats") return jsonResponse(getZirpStats());
 				if (url.pathname === "/api/runs") return jsonResponse(getRecentRuns());
+				if (url.pathname === "/api/db/tables")
+					return jsonResponse(getDbTables());
+				if (url.pathname === "/api/db/table") {
+					return jsonResponse(
+						getDbTableRows(
+							String(url.searchParams.get("name") ?? ""),
+							Number(url.searchParams.get("limit") ?? 50),
+						),
+					);
+				}
+				if (url.pathname === "/api/db/query" && request.method === "POST") {
+					const body = await readJsonBody(request);
+					return jsonResponse(runReadOnlySql(String(body.sql ?? "")));
+				}
 				if (url.pathname === "/api/search" && request.method === "POST") {
 					const body = await readJsonBody(request);
 					const query = String(body.query ?? "").trim();
@@ -823,6 +837,114 @@ function getRecentRuns() {
 	}
 }
 
+function getDbTables() {
+	if (!existsSync(KNOWLEDGE_DB_PATH)) return { tables: [] };
+	const db = new Database(`file:${KNOWLEDGE_DB_PATH}?mode=ro&immutable=1`, {
+		readonly: true,
+	});
+	try {
+		const tables = db
+			.query(`
+				SELECT name
+				FROM sqlite_master
+				WHERE type = 'table'
+					AND name NOT LIKE 'sqlite_%'
+					AND name NOT LIKE 'zirp_chunks_fts_%'
+				ORDER BY name
+			`)
+			.all() as { name: string }[];
+		return {
+			tables: tables.map((table) => ({
+				name: table.name,
+				count: getTableCount(db, table.name),
+			})),
+		};
+	} finally {
+		db.close();
+	}
+}
+
+function getTableCount(db: Database, tableName: string) {
+	try {
+		assertSafeIdentifier(tableName);
+		const row = db
+			.query(`SELECT count(*) AS count FROM "${tableName}"`)
+			.get() as {
+			count: number;
+		};
+		return row.count;
+	} catch {
+		return null;
+	}
+}
+
+function getDbTableRows(tableName: string, limitValue: number) {
+	assertSafeIdentifier(tableName);
+	const limit = Math.max(
+		1,
+		Math.min(200, Number.isFinite(limitValue) ? limitValue : 50),
+	);
+	const db = new Database(`file:${KNOWLEDGE_DB_PATH}?mode=ro&immutable=1`, {
+		readonly: true,
+	});
+	try {
+		const rows = db
+			.query(`SELECT * FROM "${tableName}" LIMIT ?`)
+			.all(limit) as Record<string, unknown>[];
+		const columns = db.query(`PRAGMA table_info("${tableName}")`).all() as {
+			name: string;
+			type: string;
+		}[];
+		return { table: tableName, columns, rows: serializeRows(rows) };
+	} finally {
+		db.close();
+	}
+}
+
+function runReadOnlySql(sql: string) {
+	const trimmed = sql.trim();
+	if (!isReadOnlySql(trimmed)) {
+		throw new Error(
+			"Only single SELECT/WITH/PRAGMA read-only queries are allowed.",
+		);
+	}
+	const db = new Database(`file:${KNOWLEDGE_DB_PATH}?mode=ro&immutable=1`, {
+		readonly: true,
+	});
+	try {
+		const rows = db.query(trimmed).all() as Record<string, unknown>[];
+		return { rows: serializeRows(rows.slice(0, 200)) };
+	} finally {
+		db.close();
+	}
+}
+
+function isReadOnlySql(sql: string) {
+	const normalized = sql.replace(/--.*$/gm, "").trim().toLowerCase();
+	if (!normalized) return false;
+	if (normalized.slice(0, -1).includes(";")) return false;
+	return /^(select|with|pragma)\b/.test(normalized);
+}
+
+function assertSafeIdentifier(identifier: string) {
+	if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+		throw new Error(`Unsafe table name: ${identifier}`);
+	}
+}
+
+function serializeRows(rows: Record<string, unknown>[]) {
+	return rows.map((row) =>
+		Object.fromEntries(
+			Object.entries(row).map(([key, value]) => [
+				key,
+				value instanceof Uint8Array
+					? `[blob ${value.byteLength} bytes]`
+					: value,
+			]),
+		),
+	);
+}
+
 function htmlResponse(html: string) {
 	return new Response(html, {
 		headers: { "content-type": "text/html; charset=utf-8" },
@@ -876,6 +998,14 @@ function renderZirpUi(options: ServeOptions) {
 		.error { color: var(--danger); margin-top: 10px; }
 		.run { border-top: 1px solid var(--line); padding: 10px 0; }
 		.run:first-child { border-top: 0; }
+		.table-list { display: grid; gap: 8px; }
+		.table-button { width: 100%; text-align: left; display: flex; justify-content: space-between; gap: 8px; }
+		.sql { min-height: 72px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+		.table-wrap { max-height: 460px; overflow: auto; border: 1px solid var(--line); border-radius: 14px; margin-top: 10px; }
+		table { width: 100%; border-collapse: collapse; font-size: 12px; }
+		th, td { border-bottom: 1px solid var(--line); padding: 8px; text-align: left; vertical-align: top; }
+		th { position: sticky; top: 0; background: var(--panel-2); color: var(--muted); }
+		td { max-width: 360px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 		@media (max-width: 880px) { .header, .grid { display: block; } .controls { grid-template-columns: 1fr; } .card { margin-top: 16px; } }
 	</style>
 </head>
@@ -912,14 +1042,24 @@ function renderZirpUi(options: ServeOptions) {
 					<button id="prompt">Prompt</button>
 					<button id="clear">Clear</button>
 				</div>
+				<details class="result">
+					<summary>SQLite scratchpad</summary>
+					<label>Read-only SQL
+						<textarea class="sql" id="sql">select name from sqlite_master where type = 'table' order by name;</textarea>
+					</label>
+					<div class="actions"><button id="runSql">Run SQL</button></div>
+				</details>
 				<div id="error" class="error" role="alert"></div>
 				<section id="answer"></section>
 				<section id="results"></section>
+				<section id="db"></section>
 			</main>
 
 			<aside class="card">
 				<h2>Index</h2>
 				<div class="stats" id="stats"></div>
+				<h2>DB tables</h2>
+				<div class="table-list" id="tables"></div>
 				<h2>Recent runs</h2>
 				<div id="runs"></div>
 			</aside>
@@ -949,6 +1089,30 @@ function renderZirpUi(options: ServeOptions) {
 
 		function renderHits(hits = []) {
 			$("results").innerHTML = hits.map((hit, index) => '<article class="result"><h3>' + (index + 1) + '. ' + escapeHtml(hit.title) + '</h3><div class="meta">' + escapeHtml(hit.tier + '/' + hit.kind) + ' · score ' + hit.score + '</div><div class="meta">' + escapeHtml(hit.sourcePath) + '</div><p>' + escapeHtml(hit.snippet) + '</p></article>').join("");
+		}
+
+		function renderRows(title, rows = []) {
+			if (!rows.length) {
+				$("db").innerHTML = '<article class="result"><h3>' + escapeHtml(title) + '</h3><p>No rows.</p></article>';
+				return;
+			}
+			const columns = Object.keys(rows[0]);
+			$("db").innerHTML = '<article class="result"><h3>' + escapeHtml(title) + '</h3><div class="table-wrap"><table><thead><tr>' + columns.map((column) => '<th>' + escapeHtml(column) + '</th>').join('') + '</tr></thead><tbody>' + rows.map((row) => '<tr>' + columns.map((column) => '<td title="' + escapeHtml(row[column]) + '">' + escapeHtml(row[column]) + '</td>').join('') + '</tr>').join('') + '</tbody></table></div></article>';
+		}
+
+		async function loadTable(name) {
+			const json = await fetch('/api/db/table?name=' + encodeURIComponent(name) + '&limit=50').then((r) => r.json());
+			renderRows('Table: ' + json.table, json.rows || []);
+		}
+
+		async function runSql() {
+			$("error").textContent = "";
+			try {
+				const json = await post('/api/db/query', { sql: $("sql").value });
+				renderRows('SQL result', json.rows || []);
+			} catch (error) {
+				$("error").textContent = error.message;
+			}
 		}
 
 		function renderAnswer(json) {
@@ -986,6 +1150,9 @@ function renderZirpUi(options: ServeOptions) {
 		async function loadSidebars() {
 			const stats = await fetch("/api/stats").then((r) => r.json());
 			$("stats").innerHTML = ['sources','chunks','runs'].map((key) => '<div class="stat"><span class="meta">' + key + '</span><strong>' + Number(stats[key] || 0).toLocaleString() + '</strong></div>').join("");
+			const tables = await fetch("/api/db/tables").then((r) => r.json());
+			$("tables").innerHTML = (tables.tables || []).map((table) => '<button class="table-button" data-table="' + escapeHtml(table.name) + '"><span>' + escapeHtml(table.name) + '</span><span class="meta">' + Number(table.count || 0).toLocaleString() + '</span></button>').join("");
+			for (const button of document.querySelectorAll('[data-table]')) button.addEventListener('click', () => loadTable(button.dataset.table));
 			const runs = await fetch("/api/runs").then((r) => r.json());
 			$("runs").innerHTML = (runs.runs || []).map((run) => '<div class="run"><div class="meta">' + escapeHtml(run.mode + ' · ' + (run.model || 'prompt')) + '</div><div>' + escapeHtml(run.query) + '</div></div>').join("") || '<p>No runs yet.</p>';
 		}
@@ -997,7 +1164,8 @@ function renderZirpUi(options: ServeOptions) {
 		$("ask").addEventListener("click", () => run("ask"));
 		$("search").addEventListener("click", () => run("search"));
 		$("prompt").addEventListener("click", () => run("prompt"));
-		$("clear").addEventListener("click", () => { $("answer").innerHTML = ""; $("results").innerHTML = ""; $("error").textContent = ""; });
+		$("runSql").addEventListener("click", runSql);
+		$("clear").addEventListener("click", () => { $("answer").innerHTML = ""; $("results").innerHTML = ""; $("db").innerHTML = ""; $("error").textContent = ""; });
 		$("query").addEventListener("keydown", (event) => { if ((event.metaKey || event.ctrlKey) && event.key === "Enter") run("ask"); });
 		loadSidebars();
 	</script>


### PR DESCRIPTION
## Summary

Adds a local `divesh_zirp` web cockpit via `bun zirp serve`, now including a native SQLite explorer powered by `bun:sqlite`.

## What changed

- Adds `bun zirp serve [--host 127.0.0.1] [--port 7331]`.
- Serves a fast local web UI for:
  - search;
  - ask;
  - prompt inspection;
  - index stats;
  - recent run history;
  - source/citation cards;
  - SQLite table browsing;
  - read-only SQL scratchpad.
- Adds local JSON API endpoints:
  - `GET /api/stats`
  - `GET /api/runs`
  - `GET /api/db/tables`
  - `GET /api/db/table?name=zirp_sources&limit=50`
  - `POST /api/db/query`
  - `POST /api/search`
  - `POST /api/prompt`
  - `POST /api/ask`
- Keeps the cockpit local-only by default by binding to `127.0.0.1`.
- Uses Bun's native SQLite driver for DB inspection, avoiding extra Datasette dependency for quick local access.
- Restricts scratchpad queries to read-only `SELECT` / `WITH` / `PRAGMA` statements.
- Adds `docs/zirp/WEB_CLIENT.md` documenting the local cockpit and a future public-facing oracle boundary.
- Updates README / ZIRP docs with the new cockpit behavior.

## Why

This turns the CLI oracle into a real research cockpit: fast search, ask, prompt inspection, run history, and lightweight DB exploration in one place.

The DB explorer is intentionally not a full replacement for Datasette/TablePlus. It is the quick local path for inspecting the exact `knowledge.db` tables behind ZIRP without leaving the cockpit.

It also sets up the right architectural boundary for eventual publishing:

- local cockpit = full private corpus, localhost only;
- public oracle = curated public corpus only, rate-limited, source-visible;
- private oracle = authenticated if needed later.

## Validation

```bash
bunx biome check scripts/zirp.ts README.md docs/zirp
bun check
bun zirp stats
bun zirp serve --port 7333
curl -sf http://127.0.0.1:7333/api/stats
curl -sf http://127.0.0.1:7333/api/db/tables
curl -sf 'http://127.0.0.1:7333/api/db/table?name=zirp_sources&limit=2'
curl -sf -X POST http://127.0.0.1:7333/api/db/query \
  -H 'content-type: application/json' \
  -d '{"sql":"select tier, count(*) count from zirp_sources group by tier order by count desc"}'
curl -sf -X POST http://127.0.0.1:7333/api/search \
  -H 'content-type: application/json' \
  -d '{"query":"games as training grounds","limit":2}'
```
