### PR TITLE
Clarify divesh_zirp refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Personal blog built with [Astro](https://astro.build).
 | `bun dev` | Start dev server at `localhost:4321` |
 | `bun build` | Build production site to `./dist/` |
 | `bun preview` | Preview build locally |
-| `bun sync api --export-library` | Sync Readwise/Zotero/etc. and export `/library` data |
+| `bun sync api --export-library` | Fetch API sources into `data/knowledge.db`, then export `/library` data |
+| `bun sync --export-library` | Export current `data/knowledge.db` to `/library` data without fetching APIs |
 | `bun sync --stats` | Show local knowledge DB stats |
 | `bun zirp inventory` | Inventory the local `divesh_zirp` corpus |
 | `bun zirp init-db` | Create namespaced `zirp_*` tables in `data/knowledge.db` |
 | `bun zirp index` | Build the local SQLite/FTS oracle index |
 | `bun zirp serve` | Open the local `divesh_zirp` web cockpit + SQLite explorer on `127.0.0.1:7331` |
 | `bun zirp search "games as training grounds"` | Search the personal oracle corpus |
-| `bun zirp ask "what should I write next?"` | Ask the oracle; uses Anthropic if configured, otherwise prints the prompt |
+| `bun zirp ask "what should I write next?"` | Ask the oracle; uses OpenAI/Anthropic if configured, otherwise prints the prompt |
 
 ## Linting & Formatting
 
@@ -91,15 +92,21 @@ Notes:
 
 ### Personal Oracle (`divesh_zirp`)
 
-A local-first personal oracle inspired by `vgr_zirp`. It retrieves from blog posts, selected notes, Versa context, Readwise/Zotero metadata, Goodreads, and Spotify, then composes grounded prompts using explicit persona docs in `docs/zirp/`.
+Local-first oracle inspired by `vgr_zirp`. It indexes blog posts, selected notes, Versa context, Readwise/Zotero metadata, Goodreads, and Spotify into `zirp_*` tables inside `data/knowledge.db`.
+
+Canonical refresh:
 
 ```bash
-bun zirp inventory
-bun zirp init-db
-bun zirp index
-bun zirp stats
-bun zirp serve
-bun zirp datasette
+bun sync api --export-library  # remote APIs → data/knowledge.db → public/data/library.json
+bun zirp inventory             # dry-run: what ZIRP sees now
+bun zirp index                 # write/rebuild zirp_* tables
+bun zirp stats                 # inspect indexed corpus
+bun zirp serve                 # local cockpit + SQLite explorer
+```
+
+Use it:
+
+```bash
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
@@ -107,7 +114,7 @@ bun zirp ask "what should I write next?"
 
 Privacy defaults: `journal/` is excluded unless `--include-journal` is passed; API calls only happen when a model API key is configured. `ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present, with Anthropic fallback.
 
-See `docs/zirp/README.md`, `docs/zirp/DX.md`, `docs/zirp/WEB_CLIENT.md`, and `docs/zirp/ARCHITECTURE.md`.
+See `docs/zirp/DX.md` for the canonical runbook.
 
 ## Content
 

--- a/docs/zirp/ARCHITECTURE.md
+++ b/docs/zirp/ARCHITECTURE.md
@@ -32,7 +32,8 @@ The indexed path:
 4. Mirror searchable text into `zirp_chunks_fts` using SQLite FTS5.
 5. Search FTS5, then re-rank candidates with title/text lexical scoring and tier weights.
 6. Dedupe by source and return top snippets.
-7. Log search/prompt/ask runs in `zirp_runs` and `zirp_run_sources` when indexed chunks are used.
+7. Log durable query/answer history in `zirp_runs`, including a JSON snapshot of retrieved sources.
+8. Log current-index chunk links in `zirp_run_sources` when indexed chunks are used.
 
 Use `--memory` to force the original in-memory search path.
 
@@ -55,7 +56,8 @@ bun zirp ask "what should I write next?"
 
 - Does not index `journal/` unless `--include-journal` is passed.
 - Does not modify notes or source data.
-- Writes only derived `zirp_*` tables inside `~/code/blog/data/knowledge.db` for indexing/run logs.
+- Writes only namespaced `zirp_*` tables inside `~/code/blog/data/knowledge.db` for indexing/run logs.
+- `bun zirp index` preserves `zirp_runs` conversation history, but rebuilds retrieval tables and current-index source links.
 - Keeps existing source-of-truth tables (`resources`, `tags`, `resource_tags`, `sync_state`) untouched.
 - Search/prompt/ask read the SQLite index when available; `--memory` bypasses it.
 - API calls are opt-in via environment variables.

--- a/docs/zirp/DX.md
+++ b/docs/zirp/DX.md
@@ -1,6 +1,18 @@
 # divesh_zirp DX walkthrough
 
-This is the daily-use runbook for the local oracle.
+This is the canonical daily-use runbook for the local oracle.
+
+## TL;DR
+
+```bash
+bun sync api --export-library  # fetch remote library data, then export site JSON
+bun zirp inventory             # dry-run scan of the live corpus
+bun zirp index                 # rebuild derived zirp_* tables
+bun zirp stats                 # inspect the indexed corpus
+bun zirp serve                 # open local cockpit at http://127.0.0.1:7331
+```
+
+Use `bun zirp -h` for CLI help.
 
 ## Mental model
 
@@ -36,8 +48,8 @@ zirp_exclusions
 ```bash
 cd ~/code/blog
 bun install
-bun sync --export-library   # if data/knowledge.db needs to be regenerated
-bun zirp init-db
+bun sync api --export-library  # if data/knowledge.db needs fresh remote data
+bun zirp init-db               # safe to rerun
 bun zirp index
 bun zirp stats
 ```
@@ -58,28 +70,54 @@ zirp chunks:  ~11k+
 
 Counts will drift as Readwise/Zotero/Spotify/Goodreads change.
 
+## Command semantics
+
+| Command | Reads | Writes | Meaning |
+| --- | --- | --- | --- |
+| `bun sync api --export-library` | Remote APIs | `data/knowledge.db`, `public/data/library.json` | Fetch Readwise/Zotero/etc., then export site JSON. |
+| `bun sync --export-library` | `data/knowledge.db` | `public/data/library.json` | Export current DB to site JSON; no remote fetch. |
+| `bun zirp inventory` | Disk + `data/knowledge.db` | Nothing | Dry-run scan: what ZIRP would index now. |
+| `bun zirp index` | Disk + `data/knowledge.db` | `zirp_*` tables | Rebuild the oracle index. |
+| `bun zirp stats` | `zirp_*` tables | Nothing | Inspect what is currently indexed. |
+| `bun zirp serve` | `zirp_*` tables | `zirp_runs` on use | Local cockpit + SQLite explorer. |
+
+Think:
+
+```txt
+inventory = live corpus preview
+index     = live corpus → zirp_* tables
+stats     = current zirp_* table counts
+```
+
+If `inventory` and `stats` disagree after syncing or editing, run `bun zirp index`.
+
+Notes from real use:
+
+- `bun sync api --export-library` may report fetched/synced API items even when the unique library count barely changes, especially for sources like Letterboxd that refresh recent entries.
+- `bun sync --export-library` only regenerates `public/data/library.json`; it does not fetch remote APIs.
+- `bun zirp inventory` can change whenever disk files or `data/knowledge.db` change. `bun zirp stats` changes only after `bun zirp index`.
+
 ## Daily use
 
-### Inventory the live corpus
+### Refresh remote library data
+
+```bash
+bun sync api --export-library
+bun zirp index
+bun zirp stats
+```
+
+Use this after adding/saving new Readwise/Zotero/Letterboxd/RAWG items.
+
+### Refresh local-only edits
 
 ```bash
 bun zirp inventory
-```
-
-This reads sources directly from disk/DB and shows what would be indexed. It does not require the SQLite ZIRP index.
-
-### Rebuild the index
-
-```bash
 bun zirp index
+bun zirp stats
 ```
 
-Run after:
-
-- editing blog posts;
-- adding notes;
-- syncing Readwise/Zotero;
-- changing Goodreads/Spotify exports.
+Use this after editing blog posts, notes, Goodreads CSV, or Spotify exports.
 
 ### Search sources
 

--- a/docs/zirp/DX.md
+++ b/docs/zirp/DX.md
@@ -264,14 +264,33 @@ Treat this as spicy mode. Rebuild without it when done:
 bun zirp index
 ```
 
+## Data safety
+
+`bun zirp index` is safe to rerun.
+
+Preserved:
+
+- source-of-truth library tables: `resources`, `tags`, `resource_tags`, `sync_state`;
+- source files: blog posts, notes, Goodreads CSV, Spotify JSON;
+- run/conversation records in `zirp_runs`.
+
+Rebuilt:
+
+- `zirp_sources`;
+- `zirp_chunks`;
+- `zirp_chunks_fts`;
+- `zirp_embeddings`;
+- `zirp_run_sources` link rows.
+
+Why `zirp_run_sources` is rebuilt/cleared: those rows point at chunk IDs from the current index. `zirp_runs` stores the durable query/answer history, plus a JSON snapshot of retrieved sources for new runs.
+
 ## Reset / rebuild
 
-Rebuild derived ZIRP tables without touching source-of-truth library tables:
+Soft reset derived retrieval tables without touching source-of-truth library tables or run history:
 
 ```bash
 sqlite3 data/knowledge.db <<'SQL'
 DELETE FROM zirp_run_sources;
-DELETE FROM zirp_runs;
 DELETE FROM zirp_embeddings;
 DELETE FROM zirp_chunks_fts;
 DELETE FROM zirp_chunks;
@@ -281,7 +300,7 @@ SQL
 bun zirp index
 ```
 
-Hard reset schema:
+Hard reset schema, including run history:
 
 ```bash
 sqlite3 data/knowledge.db <<'SQL'

--- a/docs/zirp/README.md
+++ b/docs/zirp/README.md
@@ -48,17 +48,28 @@ The goal is not to build a generic chatbot. The goal is to make the corpus query
 - `docs/zirp/DX.md` — daily-use walkthrough, model config, golden queries, and troubleshooting.
 - `docs/zirp/WEB_CLIENT.md` — local web cockpit and public-facing oracle plan.
 
-## Commands
+## Canonical workflow
 
 ```bash
-bun zirp inventory
-bun zirp init-db
-bun zirp index
-bun zirp stats
-bun zirp serve
+bun sync api --export-library  # remote APIs → data/knowledge.db → public/data/library.json
+bun zirp inventory             # dry-run: what the oracle sees now
+bun zirp index                 # rebuild zirp_* tables
+bun zirp stats                 # inspect indexed corpus
+bun zirp serve                 # local cockpit + SQLite explorer
+```
+
+Use it:
+
+```bash
 bun zirp search "games as training grounds"
 bun zirp prompt "connect WoW, feedback loops, and Versa"
 bun zirp ask "what should I write next?"
+```
+
+Help:
+
+```bash
+bun zirp -h
 ```
 
 `ask` defaults to OpenAI `gpt-5.5` with reasoning effort `low` when `OPENAI_API_KEY` is present. If OpenAI is not configured, it falls back to Anthropic when `ANTHROPIC_API_KEY` is present. If no key is configured, it prints the generated prompt so it can be pasted into any model.

--- a/docs/zirp/SQLITE_PLAN.md
+++ b/docs/zirp/SQLITE_PLAN.md
@@ -175,12 +175,14 @@ bun zirp ask "what should I write next?"
 - Default index excludes `journal/`.
 - Legal/data archive folders stay excluded.
 - Keep sensitive path rules in `zirp_exclusions`.
-- `zirp_*` tables are derived and can be dropped/rebuilt.
+- Retrieval tables (`zirp_sources`, `zirp_chunks`, `zirp_chunks_fts`, `zirp_embeddings`, `zirp_run_sources`) are derived and can be rebuilt.
+- `zirp_runs` is durable run/conversation history and should be preserved across normal `bun zirp index` runs.
+- New `zirp_runs` rows store `retrieved_sources_json` so answer/source snapshots survive index rebuilds.
 - The canonical synced library remains `resources` + `sync_state`.
 
 ## Migration safety
 
-Because the ZIRP layer is namespaced, reset is simple:
+Because the ZIRP layer is namespaced, hard reset is simple. This deletes run history too:
 
 ```sql
 DROP TABLE IF EXISTS zirp_run_sources;

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -88,7 +88,7 @@ const STOPWORDS = new Set([
 ]);
 
 function usage() {
-	console.log(`divesh_zirp v0
+	console.log(`divesh_zirp local oracle
 
 Commands:
   bun zirp inventory [--include-journal]
@@ -113,7 +113,14 @@ async function main() {
 	const cli = parseCliArgs(process.argv.slice(2));
 	const command = cli.positionals[0];
 
-	if (!command || command === "help" || command === "--help") {
+	if (
+		!command ||
+		command === "help" ||
+		command === "--help" ||
+		command === "-h" ||
+		cli.flags.has("help") ||
+		cli.flags.has("h")
+	) {
 		usage();
 		return;
 	}

--- a/scripts/zirp.ts
+++ b/scripts/zirp.ts
@@ -349,6 +349,7 @@ function initZirpDb() {
 			mode TEXT NOT NULL,
 			model TEXT,
 			response_text TEXT,
+			retrieved_sources_json TEXT,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -370,6 +371,12 @@ function initZirpDb() {
 		CREATE INDEX IF NOT EXISTS idx_zirp_sources_type ON zirp_sources(source_type);
 		CREATE INDEX IF NOT EXISTS idx_zirp_chunks_source ON zirp_chunks(source_id);
 	`,
+	);
+	ensureColumn(
+		db,
+		"zirp_runs",
+		"retrieved_sources_json",
+		"ALTER TABLE zirp_runs ADD COLUMN retrieved_sources_json TEXT",
 	);
 	db.close();
 }
@@ -564,8 +571,9 @@ function recordZirpRun(
 	const indexedHits = hits.filter((hit) => hit.metadata?.chunkId);
 	const db = openKnowledgeDb();
 	const insertRun = db.prepare(`
-		INSERT INTO zirp_runs (id, query, mode, model, response_text, created_at)
-		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO zirp_runs (
+			id, query, mode, model, response_text, retrieved_sources_json, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 	`);
 	const insertRunSource = db.prepare(`
 		INSERT INTO zirp_run_sources (run_id, chunk_id, rank, score)
@@ -574,7 +582,14 @@ function recordZirpRun(
 
 	const write = db.transaction(() => {
 		const runId = randomUUID();
-		insertRun.run(runId, query, mode, model ?? null, responseText ?? null);
+		insertRun.run(
+			runId,
+			query,
+			mode,
+			model ?? null,
+			responseText ?? null,
+			JSON.stringify(hits.map(toPublicHit)),
+		);
 		for (const [index, hit] of indexedHits.entries()) {
 			insertRunSource.run(
 				runId,
@@ -1223,6 +1238,20 @@ function runSqlScript(db: Database, sql: string) {
 	for (const statement of sql.split(";")) {
 		const trimmed = statement.trim();
 		if (trimmed) db.run(trimmed);
+	}
+}
+
+function ensureColumn(
+	db: Database,
+	tableName: string,
+	columnName: string,
+	alterSql: string,
+) {
+	const columns = db.query(`PRAGMA table_info("${tableName}")`).all() as {
+		name: string;
+	}[];
+	if (!columns.some((column) => column.name === columnName)) {
+		db.run(alterSql);
 	}
 }
 


### PR DESCRIPTION
## Summary

Cleans up the `divesh_zirp` DX docs after running the real sync/index flow and clarifies data safety semantics.

## What changed

- Fixes `bun zirp -h` / `bun zirp --help` so they show help instead of being treated as a query command.
- Renames help header from `divesh_zirp v0` to `divesh_zirp local oracle`.
- Clarifies the canonical refresh workflow:
  - `bun sync api --export-library`
  - `bun zirp inventory`
  - `bun zirp index`
  - `bun zirp stats`
  - `bun zirp serve`
- Documents command semantics:
  - `sync api --export-library` fetches remote APIs and exports JSON.
  - `sync --export-library` only exports current DB to JSON.
  - `inventory` is a dry-run live corpus scan.
  - `index` writes/rebuilds `zirp_*` tables.
  - `stats` reads current indexed state.
- Removes stale `bun zirp datasette` references from canonical docs.
- Updates README's ZIRP section to be shorter and more canonical.
- Adds a data-safety section explaining what is preserved vs rebuilt.
- Preserves durable run/conversation history in `zirp_runs` across `bun zirp index`.
- Adds `retrieved_sources_json` to `zirp_runs` so new runs keep source snapshots even if `zirp_run_sources` is rebuilt.

## Data safety semantics

Preserved:

- source-of-truth library tables: `resources`, `tags`, `resource_tags`, `sync_state`;
- source files: blog posts, notes, Goodreads CSV, Spotify JSON;
- run/conversation records in `zirp_runs`.

Rebuilt by `bun zirp index`:

- `zirp_sources`;
- `zirp_chunks`;
- `zirp_chunks_fts`;
- `zirp_embeddings`;
- `zirp_run_sources` link rows.

`zirp_run_sources` is allowed to be rebuilt because it points at current-index chunk IDs. New `zirp_runs` rows store a JSON source snapshot for durable answer/source history.

## Validation

```bash
bunx biome check scripts/zirp.ts README.md docs/zirp
bun zirp -h
bun zirp --help
bun check
bun zirp init-db
# verified retrieved_sources_json migration exists
before=$(sqlite3 data/knowledge.db "select count(*) from zirp_runs;")
bun zirp index
after=$(sqlite3 data/knowledge.db "select count(*) from zirp_runs;")
# verified before == after
```
